### PR TITLE
Removed trailing spaces, wrapped long messages.

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -2,60 +2,60 @@
 .state <- new.env(parent = emptyenv())
 
 #' Authorize user using Oauth2.0 Credentials
-#' 
-#' User will be directed to web browser and asked to sign into their Google 
-#' account and grant gspreadr access permission to user data for Google 
+#'
+#' User will be directed to web browser and asked to sign into their Google
+#' account and grant gspreadr access permission to user data for Google
 #' Spreadsheets and Google Drive. User credentials will be cached in .httr-oauth
 #' in the current working directory.
-#' 
+#'
 #' @param new_user set to \code{TRUE} if you want to wipe the slate clean and
 #'   re-authenticate with the same or different Google account
-#' 
+#'
 #' Based on \href{https://github.com/hadley/httr/blob/master/demo/oauth2-google.r}{this demo} from \code{httr}
-#' 
+#'
 #' @export
 authorize <- function(new_user = FALSE) {
-  
+
   if(new_user & file.exists(".httr-oauth")) {
     message("Removing old credentials ...")
     file.remove(".httr-oauth")
   }
-  
-  scope_list <- paste("https://spreadsheets.google.com/feeds", 
+
+  scope_list <- paste("https://spreadsheets.google.com/feeds",
                       "https://docs.google.com/feeds")
-  
+
   client_id <- getOption("gspreadr.client_id")
   client_secret <- getOption("gspreadr.client_secret")
-  
+
   gspreadr_app <- httr::oauth_app("google", client_id, client_secret)
-  
+
   google_token <-
     httr::oauth2.0_token(httr::oauth_endpoints("google"), gspreadr_app,
                          scope = scope_list, cache = TRUE)
-  
+
   # check for validity so error is found before making requests
   # shouldn't happen if id and secret don't change
   if("invalid_client" %in% unlist(google_token$credentials))
     message("Authorization error. Please check client_id and client_secret.")
-  
+
   stopifnot(inherits(google_token, "Token2.0"))
-  
+
   .state$token <- google_token
-  
+
 }
 
 
 #' Retrieve Google token from environment
-#' 
+#'
 #' Get token if it's previously stored, else prompt user to get one.
 #'
 #' @keywords internal
 get_google_token <- function() {
-  
-  if(is.null(.state$token)) {  
+
+  if(is.null(.state$token)) {
     authorize()
   }
-  
+
   token <- httr::config(token = .state$token)
-  
+
 }

--- a/R/consume-data.R
+++ b/R/consume-data.R
@@ -1,27 +1,27 @@
 #' Get all data from a rectangular worksheet as a tbl_df or data.frame
-#' 
-#' This function consumes data using the \code{exportcsv} links found in the 
-#' worksheets feed. Don't be spooked by the "csv" thing -- the data is NOT 
-#' actually written to file during this process. In fact, this is much, much 
-#' faster than consumption via the list feed. Unlike using the list feed, this 
-#' method does not assume that the populated cells form a neat rectangle. All 
+#'
+#' This function consumes data using the \code{exportcsv} links found in the
+#' worksheets feed. Don't be spooked by the "csv" thing -- the data is NOT
+#' actually written to file during this process. In fact, this is much, much
+#' faster than consumption via the list feed. Unlike using the list feed, this
+#' method does not assume that the populated cells form a neat rectangle. All
 #' cells within the "data rectangle", i.e. spanned by the maximal row and column
-#' extent of the data, are returned. Empty cells will be assigned NA. Also, the 
-#' header row, potentially containing column or variable names, is not 
-#' transformed/mangled, as it is via the list feed. If you want all of your 
+#' extent of the data, are returned. Empty cells will be assigned NA. Also, the
+#' header row, potentially containing column or variable names, is not
+#' transformed/mangled, as it is via the list feed. If you want all of your
 #' data, this is the fastest way to get it.
-#' 
+#'
 #' @inheritParams get_via_lf
-#' @param ... further arguments to be passed to \code{\link{read.csv}} or, 
-#'   ultimately, \code{\link{read.table}}; note that \code{\link{read.csv}} is 
+#' @param ... further arguments to be passed to \code{\link{read.csv}} or,
+#'   ultimately, \code{\link{read.table}}; note that \code{\link{read.csv}} is
 #'   called with \code{stringsAsFactors = FALSE}, which is the blanket policy
 #'   within \code{gspreadr} re: NOT converting character data to factor
-#'   
+#'
 #' @family data consumption functions
-#' 
+#'
 #' @return a tbl_df
-#'   
-#' @examples 
+#'
+#' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "gap_copy")
@@ -33,50 +33,49 @@
 get_via_csv <- function(ss, ws = 1, ...) {
 
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   this_ws <- get_ws(ss, ws)
-  
+
   ## since gsheets_GET expects xml back, just using GET for now
-  req <- 
-    httr::GET(this_ws$exportcsv, get_google_token())
-  
+  req <- httr::GET(this_ws$exportcsv, get_google_token())
+
   if(is.null(httr::content(req))) {
     stop("Worksheet is empty. There are no cells that contain data.")
   }
-  
+
   ## content() will process with read.csv, because req$headers$content-type is
   ## "text/csv"
   ## for empty cells, numeric columns returned as NA vs "" for chr
   #columns so set all "" to NA
-  req %>% httr::content(na.strings = c("", "NA"), ...) %>% 
+  req %>%
+    httr::content(na.strings = c("", "NA"), ...) %>%
     dplyr::as_data_frame()
-  
 }
 
 #' Get data from a rectangular worksheet as a tbl_df or data.frame
-#' 
-#' Gets data via the list feed, which assumes populated cells form a neat 
+#'
+#' Gets data via the list feed, which assumes populated cells form a neat
 #' rectangle. The list feed consumes data row by row. First row regarded as
 #' header row of variable or column names. If data is neatly rectangular and you
 #' want all of it, this is the fastest way to get it. Anecdotally, ~3x faster
 #' than using methods based on the cellfeed.
-#' 
-#' @note When you use the listfeed, the Sheets API transforms the variable or 
-#'   column names like so: 'The column names are the header values of the 
+#'
+#' @note When you use the listfeed, the Sheets API transforms the variable or
+#'   column names like so: 'The column names are the header values of the
 #'   worksheet lowercased and with all non-alpha-numeric characters removed. For
-#'   example, if the cell A1 contains the value "Time 2 Eat!" the column name 
-#'   would be "time2eat".' If this is intolerable to you, consume the data via 
-#'   the cell feed or csv download. Or, at least, consume the first row via the 
+#'   example, if the cell A1 contains the value "Time 2 Eat!" the column name
+#'   would be "time2eat".' If this is intolerable to you, consume the data via
+#'   the cell feed or csv download. Or, at least, consume the first row via the
 #'   cell feed and manually restore the variable names post hoc.
-#'   
+#'
 #' @param ss a registered Google spreadsheet
-#' @param ws positive integer or character string specifying index or title, 
+#' @param ws positive integer or character string specifying index or title,
 #'   respectively, of the worksheet to consume
-#'   
+#'
 #' @family data consumption functions
-#' 
+#'
 #' @return a tbl_df
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -85,12 +84,12 @@ get_via_csv <- function(ss, ws = 1, ...) {
 #' str(oceania_lf)
 #' oceania_lf
 #' }
-#'   
+#'
 #' @export
 get_via_lf <- function(ss, ws = 1) {
-  
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   this_ws <- get_ws(ss, ws)
   req <- gsheets_GET(this_ws$listfeed)
   row_data <- req$content %>% lfilt("entry")
@@ -108,105 +107,105 @@ get_via_lf <- function(ss, ws = 1) {
   row_data %>%
     ## get just the data, as named character vector
     plyr::llply(function(x) x[var_names] %>% unlist) %>%
-    ## rowbind to produce character matrix
-    do.call("rbind", .) %>%
-    ## drop stupid repetitive "entry" rownames
-    `rownames<-`(NULL) %>%
-    ## convert to integer, numeric, etc. but w/ stringsAsFactors = FALSE
-    plyr::alply(2, type.convert, as.is = TRUE, .dims = TRUE) %>%
-    ## get rid of attributes that are non-standard for tbl_dfs or data.frames 
-    ## and that are an artefact of the above (specifically, I think, the use of
-    ## alply?); if I don't do this, the output is fugly when you str() it
-    `attr<-`("split_type", NULL) %>%
-    `attr<-`("split_labels", NULL) %>% 
-    `attr<-`("dim", NULL) %>%
-    ## for some reason removing the non-standard dim attributes clobbers the
-    ## variable names, so those must be restored
-    `names<-`(var_names) %>% 
-    ## convert to data.frame (tbl_df, actually)
-    dplyr::as_data_frame()
-  
+      ## rowbind to produce character matrix
+      do.call("rbind", .) %>%
+      ## drop stupid repetitive "entry" rownames
+      `rownames<-`(NULL) %>%
+      ## convert to integer, numeric, etc. but w/ stringsAsFactors = FALSE
+      plyr::alply(2, type.convert, as.is = TRUE, .dims = TRUE) %>%
+      ## get rid of attributes that are non-standard for tbl_dfs or data.frames
+      ## and that are an artefact of the above (specifically, I think, the use of
+      ## alply?); if I don't do this, the output is fugly when you str() it
+      `attr<-`("split_type", NULL) %>%
+      `attr<-`("split_labels", NULL) %>%
+      `attr<-`("dim", NULL) %>%
+      ## for some reason removing the non-standard dim attributes clobbers the
+      ## variable names, so those must be restored
+      `names<-`(var_names) %>%
+      ## convert to data.frame (tbl_df, actually)
+      dplyr::as_data_frame()
 }
 
-#' Create a data.frame of the non-empty cells in a rectangular region of a 
+#' Create a data.frame of the non-empty cells in a rectangular region of a
 #' worksheet
-#' 
-#' This function consumes data via the cell feed, which, as the name suggests, 
-#' retrieves data cell by cell. No attempt is made here to shape the returned 
-#' data, but you can do that with \code{\link{reshape_cf}} and 
-#' \code{\link{simplify_cf}}). The output data.frame of \code{get_via_cf} will 
+#'
+#' This function consumes data via the cell feed, which, as the name suggests,
+#' retrieves data cell by cell. No attempt is made here to shape the returned
+#' data, but you can do that with \code{\link{reshape_cf}} and
+#' \code{\link{simplify_cf}}). The output data.frame of \code{get_via_cf} will
 #' have one row per cell.
-#' 
-#' Use the limits, e.g. min_row or max_col, to delineate the rectangular region 
-#' of interest. You can specify any subset of the limits or none at all. If 
+#'
+#' Use the limits, e.g. min_row or max_col, to delineate the rectangular region
+#' of interest. You can specify any subset of the limits or none at all. If
 #' limits are provided, validity will be checked as well as internal consistency
 #' and compliance with known extent of the worksheet. If no limits are provided,
 #' all cells will be returned but realize that \code{\link{get_via_csv}} and
 #' \code{\link{get_via_lf}} are much faster ways to consume data from a
 #' rectangular worksheet.
-#' 
-#' Empty cells, even if "embedded" in a rectangular region of populated cells, 
-#' are not normally returned by the cell feed This function won't return them 
-#' either when \code{return_empty = FALSE} (default), but will if you set 
-#' \code{return_empty = TRUE}. If you don't specify any limits AND you set 
-#' \code{return_empty = TRUE}, you could be in for several minutes wait, as the 
+#'
+#' Empty cells, even if "embedded" in a rectangular region of populated cells,
+#' are not normally returned by the cell feed This function won't return them
+#' either when \code{return_empty = FALSE} (default), but will if you set
+#' \code{return_empty = TRUE}. If you don't specify any limits AND you set
+#' \code{return_empty = TRUE}, you could be in for several minutes wait, as the
 #' feed will return all cells, which defaults to 1000 rows and 26 columns.
-#' 
+#'
 #' @inheritParams get_via_lf
 #' @param min_row positive integer, optional
 #' @param max_row positive integer, optional
 #' @param min_col positive integer, optional
 #' @param max_col positive integer, optional
-#' @param limits list, with named components holding the min and max for rows 
+#' @param limits list, with named components holding the min and max for rows
 #'   and columns; intended primarily for internal use
 #' @param return_empty logical; indicates whether to return empty cells
-#' @param return_links logical; indicates whether to return the edit and self 
+#' @param return_links logical; indicates whether to return the edit and self
 #'   links (used internally in cell editing workflow)
 #' @param verbose logical; do you want informative messages?
-#' 
-#' @examples 
+#'
+#' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "gap_copy")
 #' get_via_cf(gap_ss, "Asia", max_row = 4)
 #' reshape_cf(get_via_cf(gap_ss, "Asia", max_row = 4))
-#' reshape_cf(get_via_cf(gap_ss, "Asia", limits = list(max_row = 4, min_col = 3)))
+#' reshape_cf(get_via_cf(gap_ss, "Asia", limits = list(max_row = 4,
+#'                                                     min_col = 3)))
 #' }
 #' @family data consumption functions
-#'   
+#'
 #' @export
 get_via_cf <-
   function(ss, ws = 1,
            min_row = NULL, max_row = NULL, min_col = NULL, max_col = NULL,
            limits = NULL, return_empty = FALSE, return_links = FALSE,
            verbose = TRUE) {
-    
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-    
+
   this_ws <- get_ws(ss, ws, verbose)
-  
+
   if(is.null(limits)) {
     limits <- list("min-row" = min_row, "max-row" = max_row,
                    "min-col" = min_col, "max-col" = max_col)
   } else{
     names(limits) <- names(limits) %>% stringr::str_replace("_", "-")
   }
-  limits <- limits %>%
-    validate_limits(this_ws$row_extent, this_ws$col_extent)
-  
+  limits <- limits %>% validate_limits(this_ws$row_extent, this_ws$col_extent)
+
   query <- limits
   if(return_empty) {
-    ## the return-empty parameter is not documented in current sheets API, but 
+    ## the return-empty parameter is not documented in current sheets API, but
     ## is discussed in older internet threads re: the older gdata API; so if
     ## this stops working, consider that they finally stopped supporting this
     ## query parameter
     query <- query %>% c(list("return-empty" = "true"))
   }
   req <- gsheets_GET(this_ws$cellsfeed, query = query)
-  x <- req$content %>% lfilt("entry") %>%
+  x <- req$content %>%
+    lfilt("entry") %>%
     lapply(FUN = function(x) {
-        
-      # filled cells: "row" "col" "inputValue" stored in x$cell$.attr 
+
+      # filled cells: "row" "col" "inputValue" stored in x$cell$.attr
       # empty cells:  "row" "col" "inputValue" stored in x$cell
       # revisit this when/if we switch to xml2 ... these gymnastics may just be
       # an unsavory consequence of our use of XML::xmlToList
@@ -219,13 +218,13 @@ get_via_cf <-
         col_num <- x$cell["col"]
         text <- x$cell["inputValue"]
       }
-      
+
       links <- x %>% lfilt("^link$") %>% do.call("rbind", .) %>%
         `rownames<-`(NULL) %>%
         as.data.frame(stringsAsFactors = FALSE)
       # edit link looks like so: "path/R1C1/version"
       edit_link <- links$href[grepl("edit", links$rel)]
-      
+
       dplyr::data_frame(cell = x$title$text,
                         cell_alt = x$id %>% basename,
                         row = row_num %>% as.integer(),
@@ -237,7 +236,7 @@ get_via_cf <-
     dplyr::bind_rows()
 
   attr(x, "ws_title") <- this_ws$ws_title
-  
+
   # the pros outweighed the cons re: setting up a zero row data.frame that, at
   # least, has the correct variables
   if(nrow(x) == 0L) {
@@ -249,14 +248,13 @@ get_via_cf <-
                            edit_link = character(),
                            cell_id = character())
   }
-  
+
   if(return_links) {
     x
   } else {
     x %>%
       dplyr::select_(~ -edit_link, ~ -cell_id)
   }
-  
   # see issue #19 about all the places cell data is (mostly redundantly) stored
   # in the XML, such as:
   # content_text = x$content$text,
@@ -264,22 +262,21 @@ get_via_cf <-
   # cell_numericValue = x$cell$.attrs["numericValue"],
   # when/if we think about formulas explicitly, we will want to come back and
   # distinguish between inputValue and numericValue
-  
 }
 
 #' Get data from a row or range of rows
-#' 
+#'
 #' Get data via the cell feed for one row or for a range of rows.
-#' 
+#'
 #' @inheritParams get_via_lf
 #' @param row vector of positive integers, possibly of length one, specifying
 #'   which rows to retrieve; only contiguous ranges of rows are supported, i.e.
 #'   if \code{row = c(2, 8)}, you will get rows 2 through 8
-#'   
+#'
 #' @family data consumption functions
-#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more 
+#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more
 #'   usable data.frame
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -287,48 +284,49 @@ get_via_cf <-
 #' get_row(gap_ss, "Europe", row = 1)
 #' simplify_cf(get_row(gap_ss, "Europe", row = 1))
 #' }
-#' 
+#'
 #' @export
 get_row <- function(ss, ws = 1, row)
   get_via_cf(ss, ws, min_row = min(row), max_row = max(row))
 
 #' Get data from a column or range of columns
-#' 
+#'
 #' Get data via the cell feed for one column or for a range of columns.
-#' 
+#'
 #' @inheritParams get_via_lf
-#' @param col vector of positive integers, possibly of length one, specifying 
+#' @param col vector of positive integers, possibly of length one, specifying
 #'   which columns to retrieve; only contiguous ranges of columns are supported,
 #'   i.e. if \code{col = c(2, 8)}, you will get columns 2 through 8
-#'   
+#'
 #' @family data consumption functions
-#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more 
+#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more
 #'   usable data.frame
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "gap_copy")
 #' get_col(gap_ss, "Oceania", col = 1:2)
 #' reshape_cf(get_col(gap_ss, "Oceania", col = 1:2))
-#' } 
-#' 
+#' }
+#'
 #' @export
-get_col <- function(ss, ws = 1, col)
+get_col <- function(ss, ws = 1, col) {
   get_via_cf(ss, ws, min_col = min(col), max_col = max(col))
+}
 
 #' Get data from a cell or range of cells
-#' 
+#'
 #' Get data via the cell feed for a rectangular range of cells
-#' 
+#'
 #' @inheritParams get_via_lf
 #' @param range single character string specifying which cell or range of cells
 #'   to retrieve; positioning notation can be either "A1" or "R1C1"; a single
 #'   cell can be requested, e.g. "B4" or "R4C2" or a rectangular range can be
 #'   requested, e.g. "B2:D4" or "R2C2:R4C4"
-#'   
+#'
 #' @family data consumption functions
-#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more 
+#' @seealso \code{\link{reshape_cf}} to reshape the retrieved data into a more
 #'   usable data.frame
 #'
 #' @examples
@@ -338,24 +336,23 @@ get_col <- function(ss, ws = 1, col)
 #' get_cells(gap_ss, "Europe", range = "B3:D7")
 #' simplify_cf(get_cells(gap_ss, "Europe", range = "A1:F1"))
 #' }
-#' 
+#'
 #' @export
 get_cells <- function(ss, ws = 1, range) {
-  
-  limits <- convert_range_to_limit_list(range) 
+
+  limits <- convert_range_to_limit_list(range)
   get_via_cf(ss, ws, limits = limits)
-  
 }
 
 #' Reshape cell-level data and convert to data.frame
-#' 
+#'
 #' @param x a data.frame returned by \code{get_via_cf()}
 #' @param header logical indicating whether first row should be taken as
 #'   variable names
-#' 
+#'
 #' @family data consumption functions
-#'   
-#' @examples 
+#'
+#' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "gap_copy")
@@ -364,7 +361,7 @@ get_cells <- function(ss, ws = 1, range) {
 #' }
 #' @export
 reshape_cf <- function(x, header = TRUE) {
-  
+
   limits <- x %>%
     dplyr::summarise_each_(dplyr::funs(min, max), list(~ row, ~ col))
   all_possible_cells <-
@@ -376,9 +373,9 @@ reshape_cf <- function(x, header = TRUE) {
   ## tidyr::spread(), used below, could do something similar as this join, but
   ## it would handle completely missing rows and columns differently; still
   ## thinking about this
-  
+
   if(header) {
-    
+
     if(x_augmented$row %>% dplyr::n_distinct() < 2) {
       message("No data to reshape!")
       if(header) {
@@ -386,8 +383,8 @@ reshape_cf <- function(x, header = TRUE) {
       }
       return(NULL)
     }
-    
-    row_one <- x_augmented %>% 
+
+    row_one <- x_augmented %>%
       dplyr::filter_(~ row == min(row))
     var_names <- ifelse(is.na(row_one$cell_text),
                         stringr::str_c("C", row_one$col),
@@ -397,41 +394,40 @@ reshape_cf <- function(x, header = TRUE) {
   } else {
     var_names <- limits$col_min:limits$col_max %>% make.names()
   }
-  
+
   x_augmented %>%
     dplyr::select_(~ row, ~ col, ~ cell_text) %>%
-    tidyr::spread_("col", "cell_text", convert = TRUE) %>% 
+    tidyr::spread_("col", "cell_text", convert = TRUE) %>%
     dplyr::select_(~ -row) %>%
     setNames(var_names)
-  
 }
 
 #' Simplify data from the cell feed
-#' 
+#'
 #' In some cases, you might not want to convert the data retrieved from the cell
-#' feed into a data.frame via \code{\link{reshape_cf}}. You might prefer it as 
-#' an atomic vector. That's what this function does. Note that, unlike 
-#' \code{\link{reshape_cf}}, empty cells will NOT necessarily appear in this 
-#' result. By default, the API does not transmit data for these cells; 
+#' feed into a data.frame via \code{\link{reshape_cf}}. You might prefer it as
+#' an atomic vector. That's what this function does. Note that, unlike
+#' \code{\link{reshape_cf}}, empty cells will NOT necessarily appear in this
+#' result. By default, the API does not transmit data for these cells;
 #' \code{gspreadr} inserts these cells in \code{\link{reshape_cf}} because it is
-#' necessary to give the data rectangular shape. In contrast, empty cells will 
-#' only appear in the output of \code{simplify_cf} if they were already present 
-#' in the data from the cell feed, i.e. if the original call to 
+#' necessary to give the data rectangular shape. In contrast, empty cells will
+#' only appear in the output of \code{simplify_cf} if they were already present
+#' in the data from the cell feed, i.e. if the original call to
 #' \code{\link{get_via_cf}} had argument \code{return_empty} set to \code{TRUE}.
-#' 
+#'
 #' @inheritParams reshape_cf
-#' @param convert logical, indicating whether to attempt to convert the result 
-#'   vector from character to something more appropriate, such as logical, 
+#' @param convert logical, indicating whether to attempt to convert the result
+#'   vector from character to something more appropriate, such as logical,
 #'   integer, or numeric; if TRUE, result is passed through \code{type.convert};
 #'   if FALSE, result will be character
-#' @param as.is logical, passed through to the \code{as.is} argument of 
+#' @param as.is logical, passed through to the \code{as.is} argument of
 #'   \code{type.convert}
-#' @param notation character; the result vector will have names that reflect 
+#' @param notation character; the result vector will have names that reflect
 #'   which cell the data came from; this argument selects the positioning
 #'   notation, i.e. "A1" vs. "R1C1"
-#'   
+#'
 #' @return a named vector
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -440,31 +436,31 @@ reshape_cf <- function(x, header = TRUE) {
 #' simplify_cf(get_row(gap_ss, row = 1))
 #' simplify_cf(get_row(gap_ss, row = 1), notation = "R1C1")
 #' }
-#'   
+#'
 #' @family data consumption functions
-#'   
+#'
 #' @export
 simplify_cf <- function(x, convert = TRUE, as.is = TRUE,
                         notation = c("A1", "R1C1"), header = NULL) {
-  
+
   ## TO DO: If the input contains empty cells, maybe this function should have a
   ## way to request that cell entry "" be converted to NA?
-  
+
   notation <- match.arg(notation)
-  
+
   if(is.null(header) &&
-       x$row %>% min() == 1 &&
-       x$col %>% dplyr::n_distinct() == 1) {
+     x$row %>% min() == 1 &&
+     x$col %>% dplyr::n_distinct() == 1) {
     header <-  TRUE
   } else {
     header <- FALSE
   }
-  
+
   if(header) {
     x <- x %>%
       dplyr::filter_(~ row > min(row))
   }
-  
+
   y <- x$cell_text
   names(y) <- switch(notation,
                      A1 = x$cell,
@@ -474,7 +470,6 @@ simplify_cf <- function(x, convert = TRUE, as.is = TRUE,
   } else {
     y
   }
-  
 }
 
 ## argument validity checks and transformation
@@ -482,9 +477,9 @@ simplify_cf <- function(x, convert = TRUE, as.is = TRUE,
 ## re: min_row, max_row, min_col, max_col = query params for cell feed
 validate_limits <-
   function(limits, ws_row_extent = NULL, ws_col_extent = NULL) {
-    
+
     ## limits must be length one vector, holding a positive integer
-    
+
     ## why do I proceed this way?
     ## [1] want to preserve original invalid limits for use in error message
     ## [2] want to be able to say which element(s) of limits is/are invalid
@@ -493,13 +488,15 @@ validate_limits <-
     tmp_limits <- tmp_limits %>% plyr::llply(affirm_length_one)
     tmp_limits <- tmp_limits %>% plyr::llply(affirm_positive)
     if(any(oops <- is.na(tmp_limits))) {
-      mess <- sprintf("A row or column limit must be a single positive integer (or not given at all).\nInvalid input:\n%s",
+      mess <- sprintf(paste0("A row or column limit must be a single positive",
+                             "integer (or not given at all).\nInvalid input:\n",
+                             "%s"),
                       paste(capture.output(limits[oops]), collapse = "\n"))
       stop(mess)
     } else {
       limits <- tmp_limits
     }
-    
+
     ## min must be <= max, min and max must be <= nominal worksheet extent
     jfun <- function(x, upper_bound) {
       x_name <- deparse(substitute(x))
@@ -511,16 +508,15 @@ validate_limits <-
         stop(mess)
       }
     }
-    
+
     jfun(limits[["min-row"]], limits[["max-row"]])
     jfun(limits[["min-row"]], ws_row_extent)
     jfun(limits[["max-row"]], ws_row_extent)
     jfun(limits[["min-col"]], limits[["max-col"]])
     jfun(limits[["min-col"]], ws_col_extent)
     jfun(limits[["max-col"]], ws_col_extent)
-    
+
     limits
-    
   }
 
 affirm_not_factor <- function(x) {

--- a/R/download-spreadsheets.R
+++ b/R/download-spreadsheets.R
@@ -1,33 +1,33 @@
 #' Download a Google Sheet
-#' 
-#' Export a Google Spreadsheet as a .csv, .pdf, or .xlsx file. You can download 
-#' a spreadsheet that you own or a sheet owned by a third party that has been 
-#' made accessible via the sharing dialog options. You can download an entire 
-#' spreadsheet or a single worksheet from a spreadsheet if you provide worksheet 
-#' identifying information. If the chosen format is csv, the first worksheet 
-#' will be exported, unless another worksheet is specified. If pdf format is 
-#' chosen, all sheets will be appended into 1 pdf document. 
-#' 
-#' 
-#' @param from sheet-identifying information, either a spreadsheet object or a 
-#'   character vector of length one, giving a URL, sheet title, key or 
+#'
+#' Export a Google Spreadsheet as a .csv, .pdf, or .xlsx file. You can download
+#' a spreadsheet that you own or a sheet owned by a third party that has been
+#' made accessible via the sharing dialog options. You can download an entire
+#' spreadsheet or a single worksheet from a spreadsheet if you provide worksheet
+#' identifying information. If the chosen format is csv, the first worksheet
+#' will be exported, unless another worksheet is specified. If pdf format is
+#' chosen, all sheets will be appended into 1 pdf document.
+#'
+#'
+#' @param from sheet-identifying information, either a spreadsheet object or a
+#'   character vector of length one, giving a URL, sheet title, key or
 #'   worksheets feed
-#'   
-#' @param key character string guaranteed to provide unique key of the sheet; 
+#'
+#' @param key character string guaranteed to provide unique key of the sheet;
 #'   overrides \code{from}
-#'   
-#' @param ws positive integer or character string specifying index or title, 
-#'   respectively, of the worksheet to export ; if \code{NULL} then the entire 
+#'
+#' @param ws positive integer or character string specifying index or title,
+#'   respectively, of the worksheet to export ; if \code{NULL} then the entire
 #'   spreadsheet will be exported
-#'   
-#' @param to path to write file, if it does not contain the absolute path, 
+#'
+#' @param to path to write file, if it does not contain the absolute path,
 #' then the file is relative to the current working directory
-#' 
+#'
 #' @param verbose logical; do you want informative message?
 #' @export
-download_ss <- function(from, key = NULL, ws = NULL, 
+download_ss <- function(from, key = NULL, ws = NULL,
                         to = "my_sheet.xlsx", verbose = TRUE) {
-  
+
   if(is.null(key)) { # figure out the sheet from 'from ='
     from_ss <- from %>% identify_ss()
     key <-  from_ss$sheet_key
@@ -35,53 +35,46 @@ download_ss <- function(from, key = NULL, ws = NULL,
   } else {           # else ... take key at face value
     key
   }
-  
+
   if(!(tools::file_ext(to) %in% c("csv", "pdf", "xlsx"))) {
     stop(sprintf("Cannot download Google Spreadsheet as this format: %s",
                  tools::file_ext(to)))
   } else {
     ext <- tools::file_ext(to)
   }
-  
+
   #export a single worksheet
   if(!is.null(ws)) {
-    
     this_ws <- register_ss(key) %>% get_ws(ws)
-    
     export_links <- c(
       csv = this_ws$exportcsv,
       pdf = httr::modify_url(this_ws$exportcsv, query = list(format = "pdf")),
       xlsx = httr::modify_url(this_ws$exportcsv, query = list(format = "xlsx")))
-    
-  } else { 
+  } else {
     # get export links for entire spreadsheet
-    the_url <- paste("https://www.googleapis.com/drive/v2/files", key, sep = "/")
-    
+    the_url <- paste("https://www.googleapis.com/drive/v2/files", key,
+                     sep = "/")
     req <- gdrive_GET(the_url)
-    
     export_links <- c(
       csv = req$content$exportLinks$'text/csv', # first sheet only
       pdf = req$content$exportLinks$'application/pdf',
-      xlsx = req$content$exportLinks$'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')  
+      xlsx = req$content$exportLinks$'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
   }
-  
+
   link <- export_links %>% `[[`(ext)
-  
+
   gdrive_GET(link, httr::write_disk(to), httr::progress())
-  
+
   if(file.exists(to)) {
-    
     if(verbose) {
-      
-    if(identical(dirname(to), ".")) {
-      dir <- getwd()
-    } else {
-      dir <- dirname(to)
-    }
-    
-    message(sprintf("Sheet successfully downloaded: %s", file.path(dir, basename(to))))
-    
-    }
+      if(identical(dirname(to), ".")) {
+        dir <- getwd()
+      } else {
+        dir <- dirname(to)
+      }
+      message(sprintf("Sheet successfully downloaded: %s",
+                      file.path(dir, basename(to))))
+      }
   } else {
     stop(sprintf("Cannot confirm the file download :("))
   }

--- a/R/edit-data.R
+++ b/R/edit-data.R
@@ -1,58 +1,58 @@
 #' Edit cells
-#' 
-#' Modify the contents of one or more cells. The cells to be edited are 
-#' specified implicitly by a single anchor cell, which will be the upper left 
+#'
+#' Modify the contents of one or more cells. The cells to be edited are
+#' specified implicitly by a single anchor cell, which will be the upper left
 #' corner of the edited cell region, and the size and shape of the input. If the
-#' input has rectangular shape, i.e. is a data.frame or matrix, then a simiarly 
-#' shaped range of cells will be updated. If the input has no dimension, i.e. 
-#' it's a vector, then \code{by_row} controls whether edited cells will extend 
+#' input has rectangular shape, i.e. is a data.frame or matrix, then a simiarly
+#' shaped range of cells will be updated. If the input has no dimension, i.e.
+#' it's a vector, then \code{by_row} controls whether edited cells will extend
 #' from the anchor across a row or down a column.
-#' 
+#'
 #' @inheritParams get_via_lf
-#' @param input new cell values, as an object that can be coerced into a 
-#'   character vector, presumably an atomic vector, a factor, a matrix or a 
+#' @param input new cell values, as an object that can be coerced into a
+#'   character vector, presumably an atomic vector, a factor, a matrix or a
 #'   data.frame
-#' @param anchor single character string specifying the upper left cell of the 
+#' @param anchor single character string specifying the upper left cell of the
 #'   cell range to edit; positioning notation can be either "A1" or "R1C1"
-#' @param by_row logical; should we fill cells across a row (\code{by_row = 
-#'   TRUE}) or down a column (\code{by_row = FALSE}, default); consulted only 
+#' @param by_row logical; should we fill cells across a row (\code{by_row =
+#'   TRUE}) or down a column (\code{by_row = FALSE}, default); consulted only
 #'   when \code{input} is a vector, i.e. \code{dim(input)} is \code{NULL}
-#' @param header logical; indicates whether column names of input should be 
-#'   included in the edit, i.e. prepended to the input; consulted only when 
-#'   \code{length(dim(input))} equals 2, i.e. \code{input} is a matrix or 
+#' @param header logical; indicates whether column names of input should be
+#'   included in the edit, i.e. prepended to the input; consulted only when
+#'   \code{length(dim(input))} equals 2, i.e. \code{input} is a matrix or
 #'   data.frame
 #' @param trim logical; do you want the worksheet extent to be modified to
 #'   correspond exactly to the cells being edited?
 #' @param verbose logical; do you want informative message?
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' yo <- new_ss("yo")
 #' yo <- edit_cells(yo, input = head(iris), header = TRUE, trim = TRUE)
 #' get_via_csv(yo)
-#' 
+#'
 #' yo <- add_ws(yo, "by_row_FALSE")
 #' yo <- edit_cells(yo, ws = "by_row_FALSE", LETTERS[1:5], "A8")
 #' get_via_cf(yo, ws = "by_row_FALSE", min_row = 7) %>% simplify_cf()
-#' 
+#'
 #' yo <- add_ws(yo, "by_row_TRUE")
 #' yo <- edit_cells(yo, ws = "by_row_TRUE", LETTERS[1:5], "A8", by_row = TRUE)
 #' get_via_cf(yo, ws = "by_row_TRUE", min_row = 7) %>% simplify_cf()
 #' }
-#' 
+#'
 #' @export
 edit_cells <- function(ss, ws = 1, input = '', anchor = 'A1',
                        by_row = FALSE, header = FALSE, trim = FALSE,
                        verbose = TRUE) {
-  
+
   catch_hopeless_input(input)
   this_ws <- get_ws(ss, ws, verbose = FALSE)
-  
+
   if(dim(input) %>% is.null()) {
     if(by_row) {
       input_extent <- c(1L, length(input))
     } else {
-      input_extent <- c(length(input), 1L) 
+      input_extent <- c(length(input), 1L)
     }
   } else {
     input_extent <- dim(input)
@@ -69,108 +69,107 @@ edit_cells <- function(ss, ws = 1, input = '', anchor = 'A1',
   if(verbose) {
     message(sprintf("Range affected by the update: \"%s\"", range))
   }
-  
+
   if(limits$`max-row` > this_ws$row_extent ||
      limits$`max-col` > this_ws$col_extent) {
-    
+
     ss <- ss %>%
       resize_ws(this_ws$ws_title,
                 max(this_ws$row_extent, limits$`max-row`),
                 max(this_ws$col_extent, limits$`max-col`),
                 verbose)
-    
   }
-  
+
   input <- input %>% as_character_vector(header = header)
 
   cells_df <- ss %>%
     get_via_cf(ws, limits = limits,
                return_empty = TRUE, return_links = TRUE, verbose = FALSE) %>%
     dplyr::mutate_(update_value = ~ input)
-  
-  update_entries <- 
+
+  update_entries <-
     plyr::alply(
       cells_df, 1, function(x) {
-        XML::xmlNode("entry", 
+        XML::xmlNode("entry",
                      XML::xmlNode("batch:id", x$cell),
                      XML::xmlNode("batch:operation",
                                   attrs = c("type" = "update")),
                      XML::xmlNode("id", x$cell_id),
-                     XML::xmlNode("link", 
-                                  attrs = c("rel" = "edit", 
+                     XML::xmlNode("link",
+                                  attrs = c("rel" = "edit",
                                             "type" = "application/atom+xml",
                                             "href" = x$edit_link)),
-                     XML::xmlNode("gs:cell", 
-                                  attrs = c("row" = x$row, 
-                                            "col" = x$col, 
+                     XML::xmlNode("gs:cell",
+                                  attrs = c("row" = x$row,
+                                            "col" = x$col,
                                             "inputValue" = x$update_value)))})
-  update_feed <- 
-    XML::xmlNode("feed", 
-                 namespaceDefinitions = 
+  update_feed <-
+    XML::xmlNode("feed",
+                 namespaceDefinitions =
                    c("http://www.w3.org/2005/Atom",
                      batch = "http://schemas.google.com/gdata/batch",
                      gs = "http://schemas.google.com/spreadsheets/2006"),
                  .children = list(XML::xmlNode("id", this_ws$cellsfeed))) %>%
-    XML::addChildren(kids = update_entries) %>% XML::toString.XMLNode()
-  
+                     XML::addChildren(kids = update_entries) %>%
+                     XML::toString.XMLNode()
+
   ## TO DO: according to our policy, we should be using the capability of
   ## httr::POST() to append 'batch` here, but current version of gsheets_POST()
   ## would not support that and other edits are coming there soon ... leave it
   ## for now
   req <-
     gsheets_POST(paste(this_ws$cellsfeed, "batch", sep = "/"), update_feed)
-  
+
   ## proactive check for successful update
   cell_status <- req$content %>%
     lfilt("entry") %>%
     lapluck("status", .drop = FALSE)
   if(verbose) {
     if(all(cell_status[ , 1] == "200")) {
-      sprintf("Worksheet \"%s\" successfully updated with %d new value(s).", 
+      sprintf("Worksheet \"%s\" successfully updated with %d new value(s).",
               this_ws$ws_title, length(input)) %>% message()
     } else {
-      sprintf("Problems updating cells in worksheet \"%s\". Statuses returned:\n", 
+      sprintf(paste("Problems updating cells in worksheet \"%s\".",
+                    "Statuses returned:\n"),
               this_ws$ws_title,
-              cell_status[ , 2] %>% unique() %>% paste(sep = ",")) %>%
-        message()
+              cell_status[ , 2] %>%
+                  unique() %>%
+                  paste(sep = ",")) %>%
+                  message()
     }
   }
-  
+
   if(trim) {
-    
     ss <- ss %>%
       resize_ws(this_ws$ws_title, limits$`max-row`, limits$`max-col`, verbose)
-
   }
-  
+
   ss <- ss %>% register_ss(verbose = FALSE)
   invisible(ss)
-  
 }
 
 catch_hopeless_input <- function(x) {
-  
+
   if(x %>% is.recursive() && !(x %>% is.data.frame())) {
-    stop("Non-data-frame, list-like objects not suitable as input. Maybe pre-process it yourself?")
+    stop(paste("Non-data-frame, list-like objects not suitable as input.",                         "Maybe pre-process it yourself?"))
   }
-  
+
   if(!is.null(dim(x)) && length(dim(x)) > 2) {
     stop("Input has more than 2 dimensions.")
   }
 
   invisible(NULL)
-  
 }
 
 ## deeply pragmatic function to turn input destined for upload into cells
 ## into a character vector
 ## header controls whether column names are prepended, when x has 2 dimensions
 as_character_vector <- function(x, header = FALSE) {
-  
+
   catch_hopeless_input(x)
-  
+
   x_colnames <- NULL
-  
+
   ## instead of fiddly tests on x (see comments below), just go with it, if x
   ## can be turned into a character vector
   if(dim(x) %>% is.null()) {
@@ -179,20 +178,18 @@ as_character_vector <- function(x, header = FALSE) {
     x_colnames <- x %>% colnames()
     y <- try(x %>% t() %>% as.character() %>% drop(), silent = TRUE)
   }
-  
+
   if(y %>% inherits("try-error")) {
     stop("Input cannot be converted to character vector.")
   }
-  
+
   if(header) {
     y <- c(x_colnames, y)
   }
-  
+
   y
-  
   ## re: why vetting x directly is not as simple as you would expect
   ## http://stackoverflow.com/questions/19501186/how-to-test-if-object-is-a-vector
   ## https://twitter.com/JennyBryan/status/577950939744591872
   ## https://stat.ethz.ch/pipermail/r-devel/1997-April/017019.html
-
 }

--- a/R/edit-spreadsheets.R
+++ b/R/edit-spreadsheets.R
@@ -1,65 +1,66 @@
 #' Create a new spreadsheet
-#' 
-#' Create a new (empty) spreadsheet in your Google Drive. The new sheet will 
+#'
+#' Create a new (empty) spreadsheet in your Google Drive. The new sheet will
 #' contain 1 default worksheet titled "Sheet1".
-#' 
+#'
 #' @param title the title for the new sheet
 #' @param verbose logical; do you want informative message?
-#'   
+#'
 #' @return a gspreadsheet object
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' foo <- new_ss("foo")
 #' foo
 #' }
-#'   
+#'
 #' @export
 new_ss <- function(title = "my_sheet", verbose = TRUE) {
-  
+
   the_body <- list(title = title,
                    mimeType = "application/vnd.google-apps.spreadsheet")
-  
+
   req <-
     gdrive_POST(url = "https://www.googleapis.com/drive/v2/files", the_body)
-  
+
   ## I set verbose = FALSE here because it seems weird to message "Spreadsheet
   ## identified!" in this context, esp. to do so *before* message confirming
   ## creation
   ss <- identify_ss(title, verbose = FALSE)
-  
+
   if(verbose) {
     message(sprintf("Sheet \"%s\" created in Google Drive.", ss$sheet_title))
   }
-  
-  ss %>% register_ss() %>% invisible()
-  
+
+  ss %>%
+    register_ss() %>%
+    invisible()
 }
 
 #' Move spreadsheets to trash on Google Drive
-#' 
+#'
 #' You must own a sheet in order to move it to the trash. If you try to delete a
 #' sheet you do not own, a 403 Forbidden HTTP status code will be returned; such
-#' shared spreadsheets can only be moved to the trash manually in the web 
-#' browser. If you trash a spreadsheet that is shared with others, it will no 
-#' longer appear in any of their Google Drives. If you delete something by 
-#' mistake, remain calm, and visit the 
+#' shared spreadsheets can only be moved to the trash manually in the web
+#' browser. If you trash a spreadsheet that is shared with others, it will no
+#' longer appear in any of their Google Drives. If you delete something by
+#' mistake, remain calm, and visit the
 #' \href{https://drive.google.com/drive/#trash}{trash in Google Drive}, find the
 #' sheet, and restore it.
-#' 
-#' @param x sheet-identifying information, either a gspreadsheet object or a 
-#'   character vector of length one, giving a URL, sheet title, key or 
-#'   worksheets feed; if \code{x} is specified, the \code{regex} argument will 
+#'
+#' @param x sheet-identifying information, either a gspreadsheet object or a
+#'   character vector of length one, giving a URL, sheet title, key or
+#'   worksheets feed; if \code{x} is specified, the \code{regex} argument will
 #'   be ignored
-#' @param regex character; a regular expression; sheets whose titles match will 
+#' @param regex character; a regular expression; sheets whose titles match will
 #'   be deleted
-#' @param ... optional arguments to be passed to \code{\link{grepl}} when 
+#' @param ... optional arguments to be passed to \code{\link{grepl}} when
 #'   matching \code{regex} to sheet titles
 #' @param verbose logical; do you want informative message?
-#'   
-#' @return tbl_df with one row per specified or matching sheet, a variable 
+#'
+#' @return tbl_df with one row per specified or matching sheet, a variable
 #'   holding spreadsheet titles, a logical vector indicating deletion success
-#'   
+#'
 #' @note If there are multiple sheets with the same name and you don't want to
 #'   delete them all, identify the sheet to be deleted via key.
 #'
@@ -72,34 +73,34 @@ new_ss <- function(title = "my_sheet", verbose = TRUE) {
 #'
 #' @export
 delete_ss <- function(x = NULL, regex = NULL, verbose = TRUE, ...) {
-  
+
   ## this can be cleaned up once identify_ss() becomes less rigid
-  
+
   if(!is.null(x)) {
-    
+
     ## I set verbose = FALSE here mostly for symmetry with new_ss
     x_ss <- x %>% identify_ss(verbose = FALSE)
-    # this will throw error if no sheet is uniquely identified; tolerate for 
+    # this will throw error if no sheet is uniquely identified; tolerate for
     # now, but once identify_ss() is revised, add something here to test whether
     # we've successfully identified at least one sheet for deletion; to delete
     # multiple sheets or avoid error in case of no sheets, current workaround is
     # to use the regex argument
     keys_to_delete <- x_ss$sheet_key
     titles_to_delete <- x_ss$sheet_title
-    
+
   } else {
-    
+
     if(is.null(regex)) {
-      
+
       stop("You must specify which sheet(s) to delete.")
-      
+
     } else {
-      
+
       ss_df <- list_sheets()
       delete_me <- grepl(regex, ss_df$sheet_title, ...)
       keys_to_delete <- ss_df$sheet_key[delete_me]
       titles_to_delete <- ss_df$sheet_title[delete_me]
-      
+
       if(length(keys_to_delete) == 0L) {
         if(verbose) {
           sprintf("No matching sheets found.") %>%
@@ -109,22 +110,23 @@ delete_ss <- function(x = NULL, regex = NULL, verbose = TRUE, ...) {
       }
     }
   }
-  
+
   if(verbose) {
     sprintf("Sheets found and slated for deletion:\n%s",
-            titles_to_delete %>%paste(collapse = "\n")) %>%
-      message()
+            titles_to_delete %>%
+              paste(collapse = "\n")) %>%
+              message()
   }
 
   the_url <- paste("https://www.googleapis.com/drive/v2/files",
                    keys_to_delete, "trash", sep = "/")
-  
+
   post <- lapply(the_url, gdrive_POST, the_body = NULL)
   statii <- post %>% lapluck("status_code")
   sitrep <-
     dplyr::data_frame_(list(ss_title = ~ titles_to_delete,
                             deleted = ~(statii == 200)))
-  
+
   if(verbose) {
     if(all(sitrep$deleted)) {
       message("Success. All moved to trash in Google Drive.")
@@ -132,48 +134,47 @@ delete_ss <- function(x = NULL, regex = NULL, verbose = TRUE, ...) {
       sprintf("Oops. These sheets were NOT deleted:\n%s",
               sitrep$ss_title[!sitrep$deleted] %>%
                 paste(collapse = "\n")) %>%
-        message()
+                message()
     }
   }
-  
-  sitrep %>% invisible()
 
+  sitrep %>% invisible()
 }
 
 
 #' Make a copy of an existing spreadsheet
-#' 
-#' You can copy a spreadsheet that you own or a sheet owned by a third party 
-#' that has been made accessible via the sharing dialog options. If the sheet 
-#' you want to copy is visible in the listing provided by 
+#'
+#' You can copy a spreadsheet that you own or a sheet owned by a third party
+#' that has been made accessible via the sharing dialog options. If the sheet
+#' you want to copy is visible in the listing provided by
 #' \code{\link{list_sheets}}, you can specify it by title (or any of the other
 #' spreadsheet-identifying methods). Otherwise, you'll have to explicitly
 #' specify it by key.
-#' 
-#' @param from sheet-identifying information, either a gspreadsheet object or a 
-#'   character vector of length one, giving a URL, sheet title, key or 
+#'
+#' @param from sheet-identifying information, either a gspreadsheet object or a
+#'   character vector of length one, giving a URL, sheet title, key or
 #'   worksheets feed
-#' @param key character string guaranteed to provide unique key of the sheet; 
+#' @param key character string guaranteed to provide unique key of the sheet;
 #'   overrides \code{from}
 #' @param to character string giving the new title of the sheet; if \code{NULL},
 #'   then the copy will be titled "Copy of ..."
 #' @param verbose logical; do you want informative message?
-#'   
-#' @note if two sheets with the same name exist in your Google drive then sheet 
+#'
+#' @note if two sheets with the same name exist in your Google drive then sheet
 #'   with the most recent "last updated" timestamp will be copied.
-#'   
+#'
 #' @seealso \code{\link{identify_ss}}, \code{\link{extract_key_from_url}}
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "Gapminder_copy")
 #' gap_ss
-#' } 
-#'   
+#' }
+#'
 #' @export
 copy_ss <- function(from, key = NULL, to = NULL, verbose = TRUE) {
-  
+
   if(is.null(key)) { # figure out the sheet from 'from ='
     from_ss <- from %>% identify_ss()
     key <-  from_ss$sheet_key
@@ -181,21 +182,21 @@ copy_ss <- function(from, key = NULL, to = NULL, verbose = TRUE) {
   } else {           # else ... take key at face value
     title <- key
   }
-  
+
   the_body <- list("title" = to)
 
   the_url <-
     paste("https://www.googleapis.com/drive/v2/files", key, "copy", sep = "/")
-  
+
   req <- gdrive_POST(the_url, the_body)
-  
+
   new_title <- httr::content(req)$title
-  
+
   ## see new_ss() for why I set verbose = FALSE here
   new_ss <- try(new_title %>% identify_ss(verbose = FALSE), silent = TRUE)
-  
+
   cannot_find_sheet <- inherits(new_ss, "try-error")
-  
+
   if(verbose) {
     if(cannot_find_sheet) {
       message("Cannot verify whether spreadsheet copy was successful.")
@@ -204,31 +205,33 @@ copy_ss <- function(from, key = NULL, to = NULL, verbose = TRUE) {
                       new_ss$sheet_title))
     }
   }
-  
+
   if(cannot_find_sheet) {
     invisible(NULL)
   } else {
-    new_ss %>% register_ss() %>% invisible()
+    new_ss %>%
+      register_ss() %>%
+      invisible()
   }
 }
 
 #' Add a new (empty) worksheet to spreadsheet
-#' 
+#'
 #' Add a new (empty) worksheet to spreadsheet: specify title and worksheet
 #' extent (number of rows and columns). The title of the new worksheet can not
 #' be the same as any existing worksheets in the sheet.
-#' 
+#'
 #' @param ss a registered Google sheet
 #' @param ws_title character string for title of new worksheet
 #' @param nrow number of rows (default is 1000)
 #' @param ncol number of columns (default is 26)
 #' @param verbose logical; do you want informative message?
-#'   
+#'
 #' @return a gspreadsheet object, resulting from re-registering the host
 #'   spreadsheet after adding the new worksheet
-#'   
+#'
 #' @export
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' # get a copy of the Gapminder spreadsheet
@@ -239,51 +242,50 @@ copy_ss <- function(from, key = NULL, to = NULL, verbose = TRUE) {
 #' }
 
 add_ws <- function(ss, ws_title = "Sheet1",
-                   nrow = 1000, ncol = 26, verbose = TRUE) { 
-  
+                   nrow = 1000, ncol = 26, verbose = TRUE) {
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   ws_title_exist <- !(match(ws_title, ss$ws[["ws_title"]]) %>% is.na())
 
   if(ws_title_exist) {
     stop(sprintf("A worksheet titled \"%s\" already exists, please choose a different name.", ws_title))
   }
-  
-  the_body <- 
-    XML::xmlNode("entry", 
-                 namespaceDefinitions = 
+
+  the_body <-
+    XML::xmlNode("entry",
+                 namespaceDefinitions =
                    c("http://www.w3.org/2005/Atom",
                      gs = "http://schemas.google.com/spreadsheets/2006"),
                  XML::xmlNode("title", ws_title),
                  XML::xmlNode("gs:rowCount", nrow),
                  XML::xmlNode("gs:colCount", ncol))
-  
+
   the_body <- XML::toString.XMLNode(the_body)
-  
+
   req <- gsheets_POST(ss$ws_feed, the_body)
-  
+
   ss_refresh <- ss %>% register_ss(verbose = FALSE)
-  
+
   ws_title_exist <- !(match(ws_title, ss_refresh$ws[["ws_title"]]) %>% is.na())
-  
+
   if(verbose) {
     if(ws_title_exist) {
       message(sprintf("Worksheet \"%s\" added to sheet \"%s\".",
                       ws_title, ss_refresh$sheet_title))
     } else {
-      message(sprintf("Cannot verify whether worksheet \"%s\" was added to sheet \"%s\".",
-                      ws_title, ss_refresh$sheet_title))
+      message(sprintf(paste("Cannot verify whether worksheet \"%s\" was added",
+                            "to sheet \"%s\"."), ws_title,
+                            ss_refresh$sheet_title))
     }
   }
-  
+
   if(ws_title_exist) {
     ss_refresh %>% invisible()
   } else {
     NULL
   }
-
 }
-
 
 #' Delete a worksheet from a spreadsheet
 #'
@@ -292,71 +294,71 @@ add_ws <- function(ss, ws_title = "Sheet1",
 #' @param ss a registered Google sheet
 #' @param ws_title title of worksheet
 #' @param verbose logical; do you want informative message?
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
 #' gap_ss <- copy_ss(key = gap_key, to = "gap_copy")
 #' list_ws(gap_ss)
 #' gap_ss <- add_ws(gap_ss, "new_stuff")
-#' gap_ss <- edit_cells(gap_ss, "new_stuff", input = head(iris), header = TRUE, trim = TRUE)
+#' gap_ss <- edit_cells(gap_ss, "new_stuff", input = head(iris), header = TRUE,
+#'                      trim = TRUE)
 #' gap_ss
 #' gap_ss <- delete_ws(gap_ss, "new_stuff")
 #' list_ws(gap_ss)
 #' }
-#' 
+#'
 #' @export
 delete_ws <- function(ss, ws_title, verbose = TRUE) {
-  
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   ws_title_position <- match(ws_title, ss$ws$ws_title)
-  
+
   if(is.na(ws_title_position)) {
     stop(sprintf("No worksheet titled \"%s\" found in sheet \"%s\".",
                  ws_title, ss$sheet_title))
   }
-  
+
   req <- gsheets_DELETE(ss$ws$ws_id[ws_title_position])
-  
+
   ss_refresh <- ss %>% register_ss(verbose = FALSE)
-  
+
   ws_title_exist <- !(match(ws_title, ss_refresh$ws[["ws_title"]]) %>% is.na())
-  
+
   if(verbose) {
     if(ws_title_exist) {
-      message(sprintf("Cannot verify whether worksheet \"%s\" was deleted from sheet \"%s\".",
+      message(sprintf(paste("Cannot verify whether worksheet \"%s\" was",
+                            "deleted from sheet \"%s\"."),
                       ws_title, ss_refresh$sheet_title))
     } else {
       message(sprintf("Worksheet \"%s\" deleted from sheet \"%s\".",
                       ws_title, ss$sheet_title))
     }
   }
-  
+
   if(ws_title_exist) {
     NULL
   } else {
     ss_refresh %>% invisible()
   }
-
 }
 
-
 #' Rename a worksheet
-#' 
+#'
 #' Give a worksheet a new title that does not duplicate the title of any
 #' existing worksheet within the spreadsheet.
-#' 
+#'
 #' @param ss a registered Google sheet
 #' @param from character string for current title of worksheet
 #' @param to character string for new title of worksheet
 #' @param verbose logical; do you want informative message?
-#'   
+#'
 #' @note Since the edit link is used in the PUT request, the version path in the
-#'   url changes everytime changes are made to the worksheet, hence consecutive 
-#'   function calls using the same edit link from the same sheet object without 
+#'   url changes everytime changes are made to the worksheet, hence consecutive
+#'   function calls using the same edit link from the same sheet object without
 #'   'refreshing' it by re-registering results in a HTTP 409 Conflict.
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -365,62 +367,64 @@ delete_ws <- function(ss, ws_title, verbose = TRUE) {
 #' gap_ss <- rename_ws(gap_ss, from = "Oceania", to = "ANZ")
 #' list_ws(gap_ss)
 #' }
-#'   
+#'
 #' @export
 rename_ws <- function(ss, from, to, verbose = TRUE) {
-  
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   ws_title_position <- match(from, ss$ws$ws_title)
-  
+
   if(is.na(ws_title_position)) {
     stop(sprintf("No worksheet titled \"%s\" found in sheet \"%s\".",
                  from, ss$sheet_title))
   }
-  
+
   req <- modify_ws(ss, from = from, to = to)
   ## req carries updated info about the affected worksheet ... but I find it
   ## easier to just re-register the spreadsheet
-  
+
   ss_refresh <- ss %>% register_ss(verbose = FALSE)
-  
-  from_is_gone <- from %>% match(ss_refresh$ws$ws_title) %>% is.na()
-  to_is_there <- !(to %>% match(ss_refresh$ws$ws_title) %>% is.na())
-  
+
+  from_is_gone <- from %>%
+                    match(ss_refresh$ws$ws_title) %>%
+                    is.na()
+  to_is_there <- !(to %>%
+                     match(ss_refresh$ws$ws_title) %>%
+                     is.na())
+
   if(verbose) {
     if(from_is_gone && to_is_there) {
       message(sprintf("Worksheet \"%s\" renamed to \"%s\".", from, to))
     } else {
-      message(sprintf("Cannot verify whether worksheet \"%s\" was renamed to \"%s\".",
-                      from, to))
+      message(sprintf(paste("Cannot verify whether worksheet \"%s\" was",
+                            "renamed to \"%s\"."), from, to))
     }
   }
-  
+
   if(from_is_gone && to_is_there) {
     ss_refresh %>% invisible()
   } else {
     NULL
   }
-  
 }
 
-
 #' Resize a worksheet
-#' 
-#' Set the number of rows and columns of a worksheet. We use this function 
-#' internally during cell updates, if the data would exceed the current 
+#'
+#' Set the number of rows and columns of a worksheet. We use this function
+#' internally during cell updates, if the data would exceed the current
 #' worksheet extent. It is possible a user might want to use this directly?
-#' 
+#'
 #' This function will soon get a better ws argument, i.e. that takes integer or
 #' title, with sensible defaults.
-#' 
+#'
 #' @param ss a registered Google sheet
 #' @param ws_title character string for title of worksheet
 #' @param row_extent integer for new row extent
 #' @param col_extent integer for new column extent
 #' @param verbose logical; do you want informative message?
-#'   
-#' @note Setting rows and columns to less than the current worksheet dimensions 
+#'
+#' @note Setting rows and columns to less than the current worksheet dimensions
 #'   will delete contents without warning!
 #' @examples
 #' \dontrun{
@@ -430,20 +434,20 @@ rename_ws <- function(ss, from, to, verbose = TRUE) {
 #' yo <- resize_ws(yo, ws_title = "Sheet1", row_extent = 3, col_extent = 2)
 #' get_via_csv(yo)
 #' }
-#'   
+#'
 #' @keywords internal
 resize_ws <- function(ss, ws_title,
                       row_extent = NULL, col_extent = NULL, verbose = TRUE) {
-  
+
   stopifnot(ss %>% inherits("gspreadsheet"))
-  
+
   ws_title_position <- match(ws_title, ss$ws$ws_title)
-  
+
   if(is.na(ws_title_position)) {
     stop(sprintf("No worksheet titled \"%s\" found in sheet \"%s\".",
                  ws_title, ss$sheet_title))
   }
-  
+
   # if row or col extent not specified, make it the same as before
   if(is.null(row_extent)) {
     row_extent <- ss$ws$row_extent[ws_title_position]
@@ -451,33 +455,33 @@ resize_ws <- function(ss, ws_title,
   if(is.null(col_extent)) {
     col_extent <- ss$ws$col_extent[ws_title_position]
   }
-  
+
   req <-
     modify_ws(ss, ws_title,
               new_dim = c(row_extent = row_extent, col_extent = col_extent))
-  
+
   new_row_extent <- req$content$rowCount %>% as.integer()
   new_col_extent <- req$content$colCount %>% as.integer()
-  
+
   success <- all.equal(c(new_row_extent, new_col_extent),
                        c(row_extent, col_extent))
-  
+
   if(verbose && success) {
     message(sprintf("Worksheet \"%s\" dimensions changed to %d x %d.",
                     ws_title, new_row_extent, new_col_extent))
   }
-  
+
   if(success) {
-    ss %>% register_ss(verbose = FALSE) %>% invisible()
+    ss %>%
+      register_ss(verbose = FALSE) %>%
+      invisible()
   } else{
     NULL
   }
-
 }
 
-
 #' Modify a worksheet's title or size
-#' 
+#'
 #' @param ss a registered Google sheet
 #' @param from character string for current title of worksheet
 #' @param to character string for new title of worksheet
@@ -487,54 +491,55 @@ resize_ws <- function(ss, ws_title,
 modify_ws <- function(ss, from, to = NULL, new_dim = NULL) {
 
     stopifnot(ss %>% inherits("gspreadsheet"))
-    
+
     ws_title_position <- match(from, ss$ws$ws_title)
-    
+
     # don't want return value converted to a list, keep as XML, make edits,send
     # back via PUT
     req <- gsheets_GET(ss$ws$ws_id[ws_title_position], to_list = FALSE)
-    contents <- req %>% httr::content() %>% XML::toString.XMLNode()
-    
+    contents <- req %>%
+                  httr::content() %>%
+                  XML::toString.XMLNode()
+
     if(!is.null(to)) {
-      
       to_already_exists <- !(match(to, ss$ws$ws_title) %>% is.na())
-      
+
       if(to_already_exists) {
-        stop(sprintf("A worksheet titled \"%s\" already exists in sheet \"%s\". Please choose another worksheet title.",
+        stop(sprintf(paste("A worksheet titled \"%s\" already exists in sheet",
+                           "\"%s\". Please choose another worksheet title."),
                      to, ss$sheet_title))
       }
-      
+
       ## TO DO: we should probably be doing something more XML-y here, instead of
       ## doing XML --> string --> regex based subsitution --> XML
-      the_body <- contents %>% 
+      the_body <- contents %>%
         stringr::str_replace('(?<=<title type=\"text\">)(.*)(?=</title>)', to)
     }
-    
+
     if(!is.null(new_dim)) {
-      the_body <- contents %>% 
+      the_body <- contents %>%
         stringr::str_replace('(?<=<gs:rowCount>)(.*)(?=</gs:rowCount>)',
                              new_dim["row_extent"]) %>%
         stringr::str_replace('(?<=<gs:colCount>)(.*)(?=</gs:colCount>)',
-                             new_dim["col_extent"])         
+                             new_dim["col_extent"])
     }
-  
+
   gsheets_PUT(ss$ws$edit[ws_title_position], the_body)
-  
 }
 
 #' Upload a file and convert it to a Google Sheet
 #'
-#' Google supports the following file types to be converted to a Google 
-#' spreadsheet: .xls, .xlsx, .csv, .tsv, .txt, .tab, .xlsm, .xlt, .xltx, .xltm, 
-#' .ods. The newly uploaded file will appear in the top level of your Google 
-#' Sheets home screen. 
+#' Google supports the following file types to be converted to a Google
+#' spreadsheet: .xls, .xlsx, .csv, .tsv, .txt, .tab, .xlsm, .xlt, .xltx, .xltm,
+#' .ods. The newly uploaded file will appear in the top level of your Google
+#' Sheets home screen.
 #'
-#' @param file the file to upload, if it does not contain the absolute path, 
+#' @param file the file to upload, if it does not contain the absolute path,
 #' then the file is relative to the current working directory
-#' @param sheet_title the title of the spreadsheet; optional, 
+#' @param sheet_title the title of the spreadsheet; optional,
 #' if not specified then the name of the file will be used
 #' @param verbose logical; do you want informative message?
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' write.csv(head(iris, 5), "iris.csv", row.names = FALSE)
@@ -547,48 +552,50 @@ modify_ws <- function(ss, from, to = NULL, new_dim = NULL) {
 #'
 #' @export
 upload_ss <- function(file, sheet_title = NULL, verbose = TRUE) {
-  
+
   if(!file.exists(file)) {
     stop(sprintf("\"%s\" does not exist!", file))
   }
-  
-  ext <- c("xls", "xlsx", "csv", "tsv", "txt", "tab", "xlsm", "xlt", 
+
+  ext <- c("xls", "xlsx", "csv", "tsv", "txt", "tab", "xlsm", "xlt",
            "xltx", "xltm", "ods")
-  
+
   if(!(tools::file_ext(file) %in% ext)) {
-    stop(sprintf("Cannot convert file with this extension to a Google Spreadsheet: %s",
-                 tools::file_ext(file)))
+    stop(sprintf(paste("Cannot convert file with this extension to a Google",
+                       "Spreadsheet: %s"), tools::file_ext(file)))
   }
-  
+
   if(is.null(sheet_title)) {
     sheet_title <- file %>% basename() %>% tools::file_path_sans_ext()
   }
-  
-  req <- gdrive_POST(url = "https://www.googleapis.com/drive/v2/files", 
-                     the_body = list(title = sheet_title, 
+
+  req <- gdrive_POST(url = "https://www.googleapis.com/drive/v2/files",
+                     the_body = list(title = sheet_title,
                                      mimeType = "application/vnd.google-apps.spreadsheet"))
-  
+
   new_sheet_key <- httr::content(req)$id
-  
+
   # append sheet_key to put_url
   put_url <- httr::modify_url("https://www.googleapis.com/",
-                              path = paste0("upload/drive/v2/files/", 
+                              path = paste0("upload/drive/v2/files/",
                                             new_sheet_key))
-  
+
   gdrive_PUT(put_url, the_body = file)
-  
+
   ss_df <- list_sheets()
   success <- new_sheet_key %in% ss_df$sheet_key
-  
+
   if(success) {
     if(verbose) {
-      message(sprintf("\"%s\" uploaded to Google Drive and converted to a Google Sheet named \"%s\"",
+      message(sprintf(paste("\"%s\" uploaded to Google Drive and converted",
+                            "to a Google Sheet named \"%s\""),
                       basename(file), sheet_title))
     }
   } else {
     stop(sprintf("Cannot confirm the file upload :("))
   }
-  
-  new_sheet_key %>%  register_ss(verbose = FALSE) %>% invisible()
-  
+
+  new_sheet_key %>%
+    register_ss(verbose = FALSE) %>%
+    invisible()
 }

--- a/R/gspreadr.R
+++ b/R/gspreadr.R
@@ -1,9 +1,9 @@
 #' gspreadr
-#' 
+#'
 #' Google spreadsheets R API
-#' 
+#'
 #' See the \href{https://github.com/jennybc/gspreadr}{README} on GitHub
-#' 
+#'
 #' @docType package
 #' @name gspreadr
 #' @importFrom dplyr %>%

--- a/R/gspreadsheet.R
+++ b/R/gspreadsheet.R
@@ -1,13 +1,13 @@
 #' The gspreadsheet object
-#' 
+#'
 #' The gspreadsheet object stores information that \code{gspreadr} requires in
 #' order to communicate with the
 #' \href{https://developers.google.com/google-apps/spreadsheets/}{Google Sheets
 #' API}.
-#' 
+#'
 #' Very little of this is of interest to the user. A gspreadsheet object
 #' includes the fields:
-#' 
+#'
 #' \itemize{
 #' \item \code{sheet_key} the key of the spreadsheet
 #' \item \code{sheet_title} the title of the spreadsheet
@@ -25,11 +25,11 @@
 #' \item \code{ws} a data.frame about the worksheets contained in the
 #' spreadsheet
 #' }
-#' 
+#'
 #' TO DO: this documentation is neither here nor there. Either the object is
 #' self-explanatory and this isn't really needed. Or this needs to get beefed
 #' up. Probably the latter.
-#' 
+#'
 #' @name gspreadsheet
 gspreadsheet <- function() {
   structure(list(sheet_key = character(),
@@ -45,5 +45,4 @@ gspreadsheet <- function() {
                  links = character(), # initialize as data.frame?
                  ws = list()),
             class = c("gspreadsheet", "list"))
-  
 }

--- a/R/http-requests.R
+++ b/R/http-requests.R
@@ -1,19 +1,19 @@
 #' Create GET request
-#' 
+#'
 #' Make GET request to Google Sheets API.
-#' 
+#'
 #' @param url URL for GET request
 #' @param to_list whether to convert response contents to list or not
-#' @param ... optional; further named parameters, such as \code{query}, 
-#'   \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed 
+#' @param ... optional; further named parameters, such as \code{query},
+#'   \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed
 #'   parameters will be combined with \code{\link[httr]{config}}.
 #'
 #' @keywords internal
 gsheets_GET <- function(url, to_list = TRUE, ...) {
-  
+
   if(grepl("public", url)) {
     req <- httr::GET(url, ...)
-  } else { 
+  } else {
     req <- httr::GET(url, get_google_token(), ...)
   }
   httr::stop_for_status(req)
@@ -22,42 +22,41 @@ gsheets_GET <- function(url, to_list = TRUE, ...) {
   ## Bad Request" ... can we confidently say what the problem is?
   if(!grepl("application/atom+xml; charset=UTF-8",
             req$headers[["content-type"]], fixed = TRUE)) {
-    
+
     # DIAGNOSTIC EXPERIMENT: If I always call list_sheets() here, which seems to
-    # trigger token refresh more reliably when needed (vs register_ss), does 
+    # trigger token refresh more reliably when needed (vs register_ss), does
     # this problem go away? If so, I'll put that info to good use with a less
     # stupid fix.
     if(grepl("public", url)) {
       req <- httr::GET(url, ...)
-    } else { 
+    } else {
       req <- httr::GET(url, get_google_token(), ...)
     }
     httr::stop_for_status(req)
     if(!grepl("application/atom+xml; charset=UTF-8",
               req$headers[["content-type"]], fixed = TRUE)) {
-      stop(sprintf("Was expecting content-type to be:\n%s\nbut instead it's:\n%s\n",
-                   "application/atom+xml; charset=UTF-8",
+      stop(sprintf(paste("Was expecting content-type to be:\n%s\nbut instead",
+                         "it's:\n%s\n"), "application/atom+xml; charset=UTF-8",
                    req$headers[["content-type"]]))
     }
   }
-  # usually when the content-type is unexpectedly binary, it means we need to 
+  # usually when the content-type is unexpectedly binary, it means we need to
   # refresh the token ... we should have a better message or do something
   # constructive when this happens ... sort of waiting til I can review all the
   # auth stuff
-  
+
   ## TO DO: eventually we will depend on xml2 instead of XML and then we should
   ## use it to parse the XML instead of httr:content()
   ## see https://github.com/hadley/httr/issues/189
   ## Hadley: Yeah, I think you should be parsing this yourself, with e.g.,
   ## xml2::xml(context(r, "raw"))
   req$content <- httr::content(req, type = "text/xml", encoding = "UTF-8")
-  
+
   if(to_list) {
     req$content <- XML::xmlToList(req$content)
   }
-  
-  req
 
+  req
 }
 
 #' Create POST request
@@ -66,21 +65,21 @@ gsheets_GET <- function(url, to_list = TRUE, ...) {
 #'
 #' @param url URL for POST request
 #' @param the_body body of POST request
-#' 
+#'
 #' @keywords internal
 gsheets_POST <- function(url, the_body) {
-  
+
   token <- get_google_token()
-  
+
   if(is.null(token)) {
     stop("Must be authorized user in order to perform request")
   } else {
     # send xml to sheets api
     content_type <- "application/atom+xml"
-    
-    req <- 
-      httr::POST(url, 
-                 config = c(token, 
+
+    req <-
+      httr::POST(url,
+                 config = c(token,
                             httr::add_headers("Content-Type" = content_type)),
                  body = the_body)
     req$content <- httr::content(req, type = "text/xml")
@@ -88,11 +87,10 @@ gsheets_POST <- function(url, the_body) {
       ## known example of this: POST request triggered by add_ws()
       req$content <- XML::xmlToList(req$content)
     }
-    
+
     httr::stop_for_status(req)
-    
+
     req
-    
   }
 }
 
@@ -101,7 +99,7 @@ gsheets_POST <- function(url, the_body) {
 #' Make DELETE request to Google Sheets API.
 #'
 #' @param url URL for DELETE request
-#' 
+#'
 #' @keywords internal
 gsheets_DELETE <- function(url) {
   req <- httr::DELETE(url, get_google_token())
@@ -120,52 +118,50 @@ gsheets_DELETE <- function(url) {
 #'
 #' @keywords internal
 gsheets_PUT <- function(url, the_body) {
-  
+
   token <- get_google_token()
-  
+
   if(is.null(token)) {
     stop("Must be authorized in order to perform request")
   }
-  
+
+  content_type <- "application/atom+xml"
   req <-
-    httr::PUT(url, 
+    httr::PUT(url,
               config = c(token,
-                         httr::add_headers("Content-Type" = "application/atom+xml")), 
+                         httr::add_headers("Content-Type" = content_type)),
               body = the_body)
-  
+
   httr::stop_for_status(req)
-  
+
   req$content <- httr::content(req, type = "text/xml")
   if(!is.null(req$content)) {
     ## known example of this: POST request triggered by add_ws()
     req$content <- XML::xmlToList(req$content)
-  }  
-  
+  }
+
   req
-  
 }
 
 
 #' Make POST request to Google Drive API
 #'
 #' Used in new_ss(), delete_ss(), copy_ss()
-#' 
+#'
 #' @param url URL for POST request
 #' @param the_body body of POST request
-#' 
+#'
 #' @keywords internal
 gdrive_POST <- function(url, the_body) {
-  
+
   token <- get_google_token()
-  
+
   if(is.null(token)) {
     stop("Must be authorized user in order to perform request")
   } else {
-    
     req <- httr::POST(url, config = token, body = the_body, encode = "json")
     httr::stop_for_status(req)
     req
-    
     ## TO DO: inform users of why client error (404) Not Found may arise when
     ## copying a spreadsheet
     #     message(paste("The spreadsheet can not be found.",
@@ -177,56 +173,54 @@ gdrive_POST <- function(url, the_body) {
 
 #' Make PUT request to Google Drive API
 #'
-#' Used in upload_ss() 
+#' Used in upload_ss()
 #'
 #' @param url URL for PUT request
-#' @param the_body body of PUT request 
-#' 
+#' @param the_body body of PUT request
+#'
 #' @keywords internal
 gdrive_PUT <- function(url, the_body) {
-  
+
   token <- get_google_token()
-  
+
   if(is.null(token)) {
     stop("Must be authorized in order to perform request")
   } else {
-    
-    req <- httr::PUT(url, query = list(uploadType = "media", convert = "true"), 
-                     config = token, 
+
+    req <- httr::PUT(url, query = list(uploadType = "media", convert = "true"),
+                     config = token,
                      body = httr::upload_file(the_body))
   }
-  
+
   httr::stop_for_status(req)
-  
+
   req
-  
 }
 
 
 #' Make GET request to Google Drive API
 #'
-#' Used in download_ss() 
+#' Used in download_ss()
 #'
 #' @param url URL for GET request
-#' @param ... optional; further named parameters, such as \code{query}, 
-#'   \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed 
+#' @param ... optional; further named parameters, such as \code{query},
+#'   \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed
 #'   parameters will be combined with \code{\link[httr]{config}}.
-#'   
+#'
 #' @keywords internal
 gdrive_GET <- function(url, ...) {
-  
+
   token <- get_google_token()
-  
+
   if(is.null(token)) {
     stop("Must be authorized in order to perform request")
   } else {
     req <- httr::GET(url, config = token, ...)
   }
-  
+
   httr::stop_for_status(req)
-  
+
   req$content <- httr::content(req)
-  
+
   req
-  
 }

--- a/R/print.R
+++ b/R/print.R
@@ -1,40 +1,39 @@
 #' Print information about a Google spreadsheet registered with gspreadr
-#' 
-#' Display information about a Google spreadsheet that has been registered with 
-#' \code{gspreadr}: the title of the spreadsheet, date-time of registration, 
-#' date-time of last update (at time of registration), the number of worksheets 
+#'
+#' Display information about a Google spreadsheet that has been registered with
+#' \code{gspreadr}: the title of the spreadsheet, date-time of registration,
+#' date-time of last update (at time of registration), the number of worksheets
 #' contained, worksheet titles and extent, and sheet key.
-#' 
+#'
 #' @param x gspreadsheet object returned by \code{register_ss} and other
 #'   \code{gspreadr} functions
 #' @param ... potential further arguments (required for Method/Generic reasons)
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' foo <- new_ss("foo")
 #' foo
 #' print(foo)
 #' }
-#'   
+#'
 #' @export
-print.gspreadsheet <- function(x, ...) {  
-  
+print.gspreadsheet <- function(x, ...) {
+
   sprintf("              Spreadsheet title: %s\n", x$sheet_title) %>% cat
   sprintf("  Date of gspreadr::register_ss: %s\n",
           x$get_date %>% format.POSIXct(usetz = TRUE)) %>% cat
   sprintf("Date of last spreadsheet update: %s\n",
           x$updated %>% format.POSIXct(usetz = TRUE)) %>% cat
   cat("\n")
-  
+
   ws_output <-
     sprintf("%s: %d x %d",
             x$ws$ws_title, x$ws$row_extent, x$ws$col_extent)
   sprintf("Contains %d worksheets:\n", x$n_ws) %>% cat
   cat("(Title): (Nominal worksheet extent as rows x columns)\n")
   cat(ws_output, sep = "\n")
-  
+
   cat("\n")
   sprintf("Key: %s\n", x$sheet_key) %>% cat
   #sprintf("Worksheets feed: %s\n", x$ws_feed) %>% cat
-  
 }

--- a/R/register.R
+++ b/R/register.R
@@ -1,102 +1,108 @@
 #' Get a listing of spreadsheets
-#' 
-#' Lists spreadsheets that the authorized user would see in the Google Sheets 
-#' home screen: \url{https://docs.google.com/spreadsheets/}. For these sheets, 
-#' get sheet title, owner, user's permission, date-time of last update, the 
+#'
+#' Lists spreadsheets that the authorized user would see in the Google Sheets
+#' home screen: \url{https://docs.google.com/spreadsheets/}. For these sheets,
+#' get sheet title, owner, user's permission, date-time of last update, the
 #' unique key, and the worksheets feed.
-#' 
-#' This function returns the information available from the 
+#'
+#' This function returns the information available from the
 #' \href{https://developers.google.com/google-apps/spreadsheets/#retrieving_a_list_of_spreadsheets}{spreadsheets
 #' feed} of the Google Sheets API.
-#' 
-#' This listing give the user a partial view of the sheets available for 
-#' access (why just partial? see below). It also gives a map between readily 
-#' available information, such as sheet title, and more obscure information you 
-#' might use in scripts, such as the sheet key. This sort of "table lookup" is 
-#' implemented in the \code{gspreadr} helper function 
+#'
+#' This listing give the user a partial view of the sheets available for
+#' access (why just partial? see below). It also gives a map between readily
+#' available information, such as sheet title, and more obscure information you
+#' might use in scripts, such as the sheet key. This sort of "table lookup" is
+#' implemented in the \code{gspreadr} helper function
 #' \code{\link{identify_ss}}.
-#' 
-#' Which sheets show up here? Certainly those owned by the authorized user. But 
-#' also a subset of the sheets owned by others but visible to the authorized 
-#' user. We have yet to find explicit Google documentation on this matter. 
-#' Anecdotally, sheets shared by others seem to appear in this listing if 
-#' the authorized user has visited them in the browser. This is an important 
+#'
+#' Which sheets show up here? Certainly those owned by the authorized user. But
+#' also a subset of the sheets owned by others but visible to the authorized
+#' user. We have yet to find explicit Google documentation on this matter.
+#' Anecdotally, sheets shared by others seem to appear in this listing if
+#' the authorized user has visited them in the browser. This is an important
 #' point for usability because a sheet can be summoned by title instead of
 #' key only if it appears in this listing. For shared sheets that may not appear
-#' in this listing, a more robust workflow is to extract the key from the 
+#' in this listing, a more robust workflow is to extract the key from the
 #' browser URL via \code{\link{extract_key_from_url}} and explicitly specify the
 #' sheet in \code{gspreadr} functions by key.
-#' 
+#'
 #' @return a data.frame, one row per sheet
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' list_sheets()
 #' }
-#'   
+#'
 #' @export
 list_sheets <- function() {
-  
+
   # only calling spreadsheets feed from here, so hardwiring url
   the_url <- "https://spreadsheets.google.com/feeds/spreadsheets/private/full"
-  
+
   req <- gsheets_GET(the_url)
-  
+
   sheet_list <- req$content %>% lfilt("^entry$")
-  
-  ## wrangling prep useful for the data.frame formed below; gets the worksheets 
+
+  ## wrangling prep useful for the data.frame formed below; gets the worksheets
   ## feed for each sheet; if ends with 'values' permission is read only,
   ## if ends with 'full' permission is read/write
   ws_feed <- plyr::laply(sheet_list, function(x) {
-    links <- x %>% lfilt("^link$") %>% do.call("rbind", .) %>% 
-      as.data.frame(stringsAsFactors = FALSE)
-    links$href[grepl("2006#worksheetsfeed", links$rel)]
+    links <- x %>%
+               lfilt("^link$") %>%
+               do.call("rbind", .) %>%
+               as.data.frame(stringsAsFactors = FALSE)
+    return(links$href[grepl("2006#worksheetsfeed", links$rel)])
   })
-  
+
   dplyr::data_frame(
     sheet_title = plyr::laply(sheet_list, function(x) x$title$text),
-    sheet_key = sheet_list %>% lapluck("id") %>% basename,
+    sheet_key = sheet_list %>%
+                  lapluck("id") %>%
+                  basename,
     owner = plyr::laply(sheet_list, function(x) x$author$name),
-    perm = ws_feed %>% stringr::str_detect("values") %>% ifelse("r", "rw"),
-    last_updated = sheet_list %>% lapluck("updated") %>%
-      as.POSIXct(format = "%Y-%m-%dT%H:%M:%S", tz = "UTC"),
+    perm = ws_feed %>%
+             stringr::str_detect("values") %>%
+             ifelse("r", "rw"),
+    last_updated = sheet_list %>%
+                     lapluck("updated") %>%
+                     as.POSIXct(format = "%Y-%m-%dT%H:%M:%S", tz = "UTC"),
     ws_feed = ws_feed)
-
 }
 
 #' Retrieve the identifiers for a spreadsheet
-#' 
-#' Initialize a gspreadsheet object that holds identifying information for a 
-#' specific spreadsheet. Intended primarily for internal use. Unless 
-#' \code{verify = FALSE}, it calls \code{\link{list_sheets}} and attempts to 
-#' return information from the row uniquely specified by input \code{x}. The 
-#' listing provided by \code{\link{list_sheets}} is only available to an 
-#' authorized user, so authorization will be required. A gspreadsheet object 
-#' contains much more information than that available via 
+#'
+#' Initialize a gspreadsheet object that holds identifying information for a
+#' specific spreadsheet. Intended primarily for internal use. Unless
+#' \code{verify = FALSE}, it calls \code{\link{list_sheets}} and attempts to
+#' return information from the row uniquely specified by input \code{x}. The
+#' listing provided by \code{\link{list_sheets}} is only available to an
+#' authorized user, so authorization will be required. A gspreadsheet object
+#' contains much more information than that available via
 #' \code{\link{list_sheets}}, so many components will not be populated until the
 #' sheet is registered properly, such as via \code{\link{register_ss}}, which is
-#' called internally in many \code{gspreadr} functions. If \code{verify = 
+#' called internally in many \code{gspreadr} functions. If \code{verify =
 #' FALSE}, then user must provide either sheet key, URL or a worksheets feed, as
-#' opposed to sheet title. In this case, the information will be taken at face 
+#' opposed to sheet title. In this case, the information will be taken at face
 #' value, i.e. no proactive verification or look-up on Google Drive.
-#' 
+#'
 #' This function is will be revised to be less dogmatic about only identifying
 #' ONE sheet.
-#' 
-#' @param x sheet-identifying information, either a gspreadsheet object or a 
-#'   character vector of length one, giving a URL, sheet title, key or 
+#'
+#' @param x sheet-identifying information, either a gspreadsheet object or a
+#'   character vector of length one, giving a URL, sheet title, key or
 #'   worksheets feed
-#' @param method optional character string specifying the method of sheet 
+#' @param method optional character string specifying the method of sheet
 #'   identification; if given, must be one of: URL, key, title, ws_feed, or ss
-#' @param verify logical, default is TRUE, indicating if sheet should be looked 
+#' @param verify logical, default is TRUE, indicating if sheet should be looked
 #'   up in the list of sheets obtained via \code{\link{list_sheets}}
 #' @param visibility character, default is "private", indicating whether to form
 #'   a worksheets feed that anticipates requests with authentication ("private")
 #'   or without ("public"); only consulted when \code{verify = FALSE}
 #' @param verbose logical
-#'   
+#'
 #' @return a gspreadsheet object
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -105,30 +111,34 @@ list_sheets <- function() {
 #' gap_ss <- register_ss(gap_id)
 #' gap_ss      # much more available after registration
 #' }
-#'   
+#'
 #' @export
 identify_ss <- function(x, method = NULL, verify = TRUE,
                         visibility = "private", verbose = TRUE) {
-  
+
   if(!inherits(x, "gspreadsheet")) {
     if(!is.character(x)) {
-      stop("The information that specifies the sheet must be character, regardless of whether it is the URL, title, key or worksheets feed.")
+      stop(paste("The information that specifies the sheet must be character,",
+                 "regardless of whether it is the URL, title, key or",
+                 "worksheets feed."))
     } else {
       if(length(x) != 1) {
-        stop("The character vector that specifies the sheet must be of length 1.")
-      }    
+        stop(paste("The character vector that specifies the sheet must be of",
+                   "length 1."))
+      }
     }
   }
-  
+
   method <-
     match.arg(method,
               choices = c('unknown', 'url', 'key', 'title', 'ws_feed', 'ss'))
-  
+
   ## is x a gspreadsheet object?
   if(method == 'ss' || inherits(x, "gspreadsheet")) {
     if(verify) {
       if(verbose) {
-        message("Identifying info is a gspreadsheet object; gspreadr will re-identify the sheet based on sheet key.")
+        message(paste("Identifying info is a gspreadsheet object; gspreadr",
+                      "will re-identify the sheet based on sheet key."))
       }
       x <- x$sheet_key
       method <- 'key'
@@ -137,7 +147,7 @@ identify_ss <- function(x, method = NULL, verify = TRUE,
       return(x)
     }
   } ## if x was ss, x is now a key
-  
+
   ## is x a URL but NOT a worksheets feed?
   ws_feed_start <- "https://spreadsheets.google.com/feeds/worksheets"
   if(method == 'url' ||
@@ -145,7 +155,8 @@ identify_ss <- function(x, method = NULL, verify = TRUE,
       !(x %>% stringr::str_detect(ws_feed_start))
      )) {
     if(verbose) {
-      message("Identifying info will be processed as a URL.\ngspreadr will attempt to extract sheet key from the URL.")
+      message(paste("Identifying info will be processed as a URL.\ngspreadr",
+                    "will attempt to extract sheet key from the URL."))
     }
     x <- x %>% extract_key_from_url()
     method <- 'key'
@@ -154,15 +165,14 @@ identify_ss <- function(x, method = NULL, verify = TRUE,
       message(mess)
     }
   } ## if x was URL (but not ws_feed), x is now a key
-  
+
   ## x is now known or presumed to be key, title, or ws_feed
-  
+
   if(!verify) {
-    
     if(method == 'title') {
       stop("Impossible to identify a sheet based on title when verify = FALSE. gspreadr must look up the title to obtain key or worksheets feed.")
     }
-    
+
     ## if method still unknown, make a guess between key or ws_feed
     if(method == 'unknown') {
       if(x %>% stringr::str_detect(ws_feed_start)) {
@@ -171,113 +181,119 @@ identify_ss <- function(x, method = NULL, verify = TRUE,
         method <- 'key'
       }
     }
-    
+
     if(verbose) {
       message(sprintf("Identifying info will be handled as: %s.", method))
     }
-    
+
     ss <- gspreadsheet()
-    
+
     if(method == 'key') {
       ss$sheet_key <- x
       ss$ws_feed <- construct_ws_feed_from_key(x, visibility)
     }
-    
+
     if(method == 'ws_feed') {
       ss$ws_feed <- x
       ss$sheet_key <- x %>% extract_key_from_url()
     }
-    
+
     if(verbose) {
       message(sprintf("Unverified sheet key: %s.", ss$sheet_key))
       #message(sprintf("Unverified worksheets feed: %s.", ss$ws_feed))
     }
-    
+
     return(ss)
   }
-  
+
   ## we need listing of sheets visible to this user
   ssfeed_df <- list_sheets() %>%
     dplyr::select_(~ sheet_title, ~sheet_key, ~ws_feed)
-  
+
   ## can we find x in the variables that hold identifiers?
   match_here <- ssfeed_df %>%
     ## using llply, not match, to detect multiple matches
     plyr::llply(function(z) which(z == x))
-  
+
   n_match <- match_here %>% plyr::laply(length)
-  
+
   if(any(n_match > 1)) { # oops! multiple matches within identifier(s)
-    mess <- sprintf("Identifying info \"%s\" has multiple matches in these identifiers: %s\n", x, names(match_here)[n_match > 1])
+    mess <- sprintf(paste("Identifying info \"%s\" has multiple matches in",
+                          "these identifiers: %s\n"), x,
+                    names(match_here)[n_match > 1])
     stop(mess)
   } else { # at most one match per identifier, so unlist now
     match_here <- match_here %>% unlist()
   }
-  
+
   if(all(n_match < 1)) { # oops! no match anywhere
-    mess <- sprintf("Identifying info \"%s\" doesn't match title, key, or worksheets feed for any sheet listed in the Google sheets home screen for authorized user.", x)
+    mess <- sprintf(paste("Identifying info \"%s\" doesn't match title, key,",
+                          "or worksheets feed for any sheet listed in the",
+                          "Google sheets home screen for authorized user."), x)
     stop(mess)
   }
-  
+
   if(match_here %>% unique() %>% length() > 1) { # oops! conflicting matches
-    mess <- sprintf("Identifying info \"%s\" has conflicting matches in multiple identifiers: %s\n", x,
-                    names(match_here)[n_match > 0] %>% stringr::str_c(collapse = ", "))
+    mess <- sprintf(paste("Identifying info \"%s\" has conflicting matches in",
+                          "multiple identifiers: %s\n"), x,
+                    names(match_here)[n_match > 0] %>%
+                      stringr::str_c(collapse = ", "))
     stop(mess)
   }
-  
+
   the_match <- match_here %>% unique()
   x_ss <- ssfeed_df[the_match, ] %>% as.list()
-  
+
   if(verbose) {
     #mess <- sprintf("Sheet identified!\nsheet_title: %s\nsheet_key: %s\nws_feed: %s\n", x_ss$sheet_title, x_ss$sheet_key, x_ss$ws_feed)
-    mess <- sprintf("Sheet identified!\nsheet_title: %s\nsheet_key: %s\n", x_ss$sheet_title, x_ss$sheet_key)
+    mess <- sprintf("Sheet identified!\nsheet_title: %s\nsheet_key: %s\n",
+                    x_ss$sheet_title, x_ss$sheet_key)
     message(mess)
   }
-  
+
   ss <- gspreadsheet()
   ss$sheet_key <- x_ss$sheet_key
   ss$sheet_title <- x_ss$sheet_title
   ss$ws_feed <- x_ss$ws_feed
-  
+
   ss
-  
 }
 
 #' Register a Google spreadsheet
-#' 
-#' Specify a Google spreadsheet via its URL, unique key, title, or worksheets 
-#' feed and register it for further use. This function returns an object of 
-#' class \code{gspreadsheet}, which contains all the information other 
+#'
+#' Specify a Google spreadsheet via its URL, unique key, title, or worksheets
+#' feed and register it for further use. This function returns an object of
+#' class \code{gspreadsheet}, which contains all the information other
 #' \code{gspreadr} functions will need to consume data from the sheet or to edit
-#' the sheet. This object also contains sheet information that may be of 
-#' interest to the user, such as the time of last update, the number of 
+#' the sheet. This object also contains sheet information that may be of
+#' interest to the user, such as the time of last update, the number of
 #' worksheets contained, and their titles.
-#' 
-#' @param x character vector of length one, with sheet-identifying information; 
+#'
+#' @param x character vector of length one, with sheet-identifying information;
 #'   valid inputs are title, key, URL, worksheets feed
 #' @param key character vector of length one that is guaranteed to be unique key
 #'   for sheet; supercedes argument \code{x}
-#' @param ws_feed character vector of length one that is guaranteed to be 
+#' @param ws_feed character vector of length one that is guaranteed to be
 #'   worksheets feed for sheet; supercedes arguments \code{x} and \code{key}
-#' @param visibility either "public" or "private"; used to specify visibility 
+#' @param visibility either "public" or "private"; used to specify visibility
 #'   when sheet identified via \code{key}
 #' @param verbose logical; do you want informative message?
-#'   
+#'
 #' @return Object of class gspreadsheet.
-#'   
-#' @note Re: the reported extent of the worksheets. Contain your excitement, 
-#'   because it may not be what you think or hope it is. It does not report how 
-#'   many rows or columns are actually nonempty. This cannot be determined via 
+#'
+#' @note Re: the reported extent of the worksheets. Contain your excitement,
+#'   because it may not be what you think or hope it is. It does not report how
+#'   many rows or columns are actually nonempty. This cannot be determined via
 #'   the Google sheets API without consuming the data and noting which cells are
 #'   populated. Therefore, these numbers often reflect the default extent of a
-#'   new worksheet, e.g., 1000 rows and 26 columns at the time or writing, and 
+#'   new worksheet, e.g., 1000 rows and 26 columns at the time or writing, and
 #'   provide an upper bound on the true number of rows and columns.
-#'   
-#' @note The visibility can only be "public" if the sheet is "Published to the 
-#'   web". Gotcha: this is different from setting the sheet to "Public on the 
-#'   web" in the visibility options in the sharing dialog of a Google Sheets 
+#'
+#' @note The visibility can only be "public" if the sheet is "Published to the
+#'   web". Gotcha: this is different from setting the sheet to "Public on the
+#'   web" in the visibility options in the sharing dialog of a Google Sheets
 #'   file.
-#'   
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -285,11 +301,11 @@ identify_ss <- function(x, method = NULL, verify = TRUE,
 #' gap_ss
 #' get_row(gap_ss, "Africa", row = 1)
 #' }
-#'   
+#'
 #' @export
 register_ss <- function(x, key = NULL, ws_feed = NULL,
                         visibility = "private", verbose = TRUE) {
-  
+
   if(is.null(ws_feed)) {
     if(is.null(key)) { # get ws_feed from x
       ws_feed <- x %>%
@@ -299,60 +315,66 @@ register_ss <- function(x, key = NULL, ws_feed = NULL,
       ws_feed <- construct_ws_feed_from_key(key, visibility)
     }
   }                    # else ... take ws_feed at face value
-  
+
   req <- gsheets_GET(ws_feed)
-  
+
   if(grepl("html", req$headers[["content-type"]])) {
-    ## TO DO: give more specific error message. Have they said "public" when 
+    ## TO DO: give more specific error message. Have they said "public" when
     ## they meant "private" or vice versa? What's the actual problem and
     ## solution?
     stop("Please check visibility settings.")
   }
-  
+
   ss <- gspreadsheet()
-  
+
   ss$sheet_key <- ws_feed %>% extract_key_from_url()
   ss$sheet_title <- req$content[["title"]][["text"]]
   ss$n_ws <- req$content[["totalResults"]] %>% as.integer()
-  
+
   ss$ws_feed <- req$url               # same as sheet_id ... pick one?
   ss$sheet_id <- req$content[["id"]]  # same as ws_feed ... pick one?
   # for that matter, this URL appears a third time as the "self" link below :(
-  
+
   ss$updated <- req$content[["updated"]] %>%
     as.POSIXct(format = "%Y-%m-%dT%H:%M:%S", tz = "UTC")
   ss$get_date <- req$date
-  
+
   ## I'm ambivalent about even storing this; it's baked into the links
   ## holdover from an earlier stage of pkg development ... omit?
   ss$visibility <- req$url %>% dirname %>% basename
-  
+
   ss$author_name <- req$content[["author"]][["name"]]
   ss$author_email <- req$content[["author"]][["email"]]
-  
+
   ss$links <- req$content %>%
     lfilt("^link$") %>%
     plyr::ldply() %>% dplyr::select_(quote(-.id))
   ## select_() will be unnecessary when this PR gets merged into plyr
   ## https://github.com/hadley/plyr/pull/207
   ## and ldply handles '.id = NULL' correctly
-  
+
   ws_list <- req$content %>% lfilt("^entry$")
   ws_info <-
     dplyr::data_frame_(
       list(ws_id = ~ ws_list %>% lapluck("id"),
            ws_key = ~ ws_id %>% basename,
            ws_title = ~ plyr::laply(ws_list, function(x) x$title$text),
-           row_extent = ~ ws_list %>% lapluck("rowCount") %>% as.integer(),
+           row_extent = ~ ws_list %>%
+                            lapluck("rowCount") %>%
+                            as.integer(),
            col_extent = ~ ws_list %>% lapluck("colCount") %>% as.integer()))
   ws_links <- plyr::ldply(ws_list, function(x) {
-    links <- x %>% lfilt("^link$") %>% do.call("cbind", .)
+    links <- x %>%
+               lfilt("^link$") %>%
+               do.call("cbind", .)
     links["href", ] %>%
-      setNames(links["rel", ] %>% basename %>%
+      setNames(links["rel", ] %>%
+                 basename %>%
                  stringr::str_replace("[0-9]{4}#", ""))
-  }) %>% dplyr::select_(quote(-.id))
+  }) %>%
+    dplyr::select_(quote(-.id))
   ## see comment above about ldply(.id = NULL)
-  
+
   ss$ws <- dplyr::bind_cols(ws_info, ws_links)
   ss
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,29 +1,29 @@
 #' Retrieve a worksheet-describing list from a gspreadsheet
-#' 
+#'
 #' From a gspreadsheet, retrieve a list (actually a row of a data.frame) giving
 #' everything we know about a specific worksheet.
-#' 
+#'
 #' @inheritParams get_via_lf
 #' @param verbose logical, indicating whether to give a message re: title of the
 #'   worksheet being accessed
-#'   
+#'
 #' @keywords internal
 get_ws <- function(ss, ws, verbose = TRUE) {
-  
+
   stopifnot(inherits(ss, "gspreadsheet"),
             length(ws) == 1L,
             is.character(ws) || (is.numeric(ws) && ws > 0))
-  
+
   if(is.character(ws)) {
     index <- match(ws, ss$ws$ws_title)
     if(is.na(index)) {
-      stop(sprintf("Worksheet %s not found.", ws))    
+      stop(sprintf("Worksheet %s not found.", ws))
     } else {
       ws <- index %>% as.integer()
     }
   }
   if(ws > ss$n_ws) {
-    stop(sprintf("Spreadsheet only contains %d worksheets.", ss$n_ws)) 
+    stop(sprintf("Spreadsheet only contains %d worksheets.", ss$n_ws))
   }
   if(verbose) {
     message(sprintf("Accessing worksheet titled \"%s\"", ss$ws$ws_title[ws]))
@@ -32,11 +32,11 @@ get_ws <- function(ss, ws, verbose = TRUE) {
 }
 
 #' List the worksheets in a gspreadsheet
-#' 
+#'
 #' Retrieve the titles of all the worksheets in a gpreadsheet.
-#' 
+#'
 #' @inheritParams get_via_lf
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_key <- "1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA"
@@ -45,22 +45,21 @@ get_ws <- function(ss, ws, verbose = TRUE) {
 #' }
 #' @export
 list_ws <- function(ss) {
-  
-  stopifnot(inherits(ss, "gspreadsheet"))
-  
-  ss$ws$ws_title
 
+  stopifnot(inherits(ss, "gspreadsheet"))
+
+  ss$ws$ws_title
 }
 
 #' Convert column IDs from letter representation to numeric
 #'
 #' @param x character vector of letter-style column IDs (case insensitive)
-#' 
+#'
 #' @keywords internal
 letter_to_num <- function(x) {
   x %>%
     toupper() %>%
-    stringr::str_split('') %>% 
+    stringr::str_split('') %>%
     plyr::llply(match, table = LETTERS) %>%
     plyr::laply(function(z) sum(26 ^ rev(seq_along(z) - 1) * z)) %>%
     unname()
@@ -69,7 +68,7 @@ letter_to_num <- function(x) {
 #' Convert column IDs from numeric to letter representation
 #'
 #' @param x vector of numeric column IDs
-#' 
+#'
 #' @keywords internal
 num_to_letter <- function(x) {
   stopifnot(x <= letter_to_num('ZZ')) # Google spreadsheets have 300 columns max
@@ -80,7 +79,7 @@ num_to_letter <- function(x) {
 #' Convert A1 positioning notation to R1C1 notation
 #'
 #' @param x cell position in A1 notation
-#' 
+#'
 #' @keywords internal
 label_to_coord <- function(x) {
   paste0("R", stringr::str_extract(x, "[[:digit:]]*$") %>% as.integer(),
@@ -90,7 +89,7 @@ label_to_coord <- function(x) {
 #' Convert R1C1 positioning notation to A1 notation
 #'
 #' @param x cell position in R1C1 notation
-#' 
+#'
 #' @keywords internal
 coord_to_label <- function(x) {
   paste0(sub("^R[0-9]+C([0-9]+)$", "\\1", x) %>%
@@ -101,10 +100,10 @@ coord_to_label <- function(x) {
 #' Convert a cell range into a limits list
 #'
 #' @param range character vector, length one, such as "A1:D7"
-#' 
+#'
 #' @keywords internal
 convert_range_to_limit_list <- function(range) {
-  
+
   tmp <- range %>%
     stringr::str_split_fixed(":", 2) %>% ## A1:C5 --> "A1", "D5" as 1-row matrix
     drop() %>%                           ## 1-row matrix --> vector
@@ -112,23 +111,24 @@ convert_range_to_limit_list <- function(range) {
       x <- .[. != ""]                    ## replicate the single address
       rep_len(x, 2)                      ## "C5" --> "C5", "" --> "C5", "C5"
     }
-  
+
   A1_regex <- "^[A-Za-z]{1,2}[0-9]+$"
   R1C1_regex <- "^R([0-9]+)C([0-9]+$)"
   valid_regex <- stringr::str_c(c(A1_regex, R1C1_regex), collapse = "|")
   if(!all(tmp %>% stringr::str_detect(valid_regex))) {
-    mess <- sprintf("Trying to set cell limits, but requested range is invalid:\n %s\n", paste(tmp, collapse = ", "))
+    mess <- sprintf(paste("Trying to set cell limits, but requested range is",
+                          "invalid:\n %s\n"), paste(tmp, collapse = ", "))
     stop(mess)
   }
-  
+
   ## convert addresses like "B4" to "R4C2"
   rcrc <- all(tmp %>% stringr::str_detect("^R[0-9]+C[0-9]+$"))
   if(!rcrc) {
     tmp <- tmp %>% label_to_coord()    ## "A1", "C5" --> "R1C1", "R5C4"
   }
-  
+
   ## complete conversion to a limits list
-  tmp %>% 
+  tmp %>%
     ## "R1C1", "R5C4" --> matrix w/ 2 rows, one per cell
     ## 3 columns: full address, the row part, the column part
     stringr::str_match("^R([0-9]+)C([0-9]+$)") %>%
@@ -136,28 +136,27 @@ convert_range_to_limit_list <- function(range) {
     as.integer() %>%                     ## convert character to integer
     as.list() %>%                        ## convert to a list
     setNames(c("min-row", "max-row", "min-col", "max-col")) ## names matter!
-  
+
 }
 
-#' Convert a limits list to a cell range 
+#' Convert a limits list to a cell range
 #'
 #' @param limits limits list
 #' @param pn positioning notation
-#' 
+#'
 #' @keywords internal
 convert_limit_list_to_range <- function(limits, pn = c('R1C1', 'A1')) {
 
   pn <- match.arg(pn)
-  
+
   range <- c(paste0("R", limits$`min-row`, "C", limits$`min-col`),
              paste0("R", limits$`max-row`, "C", limits$`max-col`))
-  
+
   if(pn == 'A1') {
     range <- range %>% coord_to_label()
   }
-  
-  paste(range, collapse = ":")
 
+  paste(range, collapse = ":")
 }
 
 
@@ -166,21 +165,21 @@ convert_limit_list_to_range <- function(limits, pn = c('R1C1', 'A1')) {
 ## see #12 for plan re: getting outside help for FP w/ lists
 
 #' Filter a list by name
-#' 
+#'
 #' @param x a list
 #' @param name a regular expression
 #' @param ... other parameters you might want to pass to grep
-#' 
+#'
 #' @keywords internal
 lfilt <- function(x, name, ...) {
   x[grep(name, names(x), ...)]
 }
 
 #' Pluck out elements from list components by name
-#' 
+#'
 #' @param x a list
 #' @param xpath a string giving the name of the component you want, XPath style
-#' 
+#'
 #' @keywords internal
 llpluck <- function(x, xpath) {
   x %>% plyr::llply("[[", xpath) %>% plyr::llply(unname)
@@ -195,9 +194,9 @@ lapluck <- function(x, xpath, .drop = TRUE) {
 str1 <- function(...) str(..., max.level = 1)
 
 #' Extract sheet key from its browser URL
-#' 
+#'
 #' @param url URL seen in the browser when visiting the sheet
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' gap_url <- "https://docs.google.com/spreadsheets/d/1HT5B8SgkKqHdqHJmn5xiuaC04Ngb7dG9Tv94004vezA/"
@@ -205,7 +204,7 @@ str1 <- function(...) str(..., max.level = 1)
 #' gap_ss <- register_ss(gap_key)
 #' gap_ss
 #' }
-#' 
+#'
 #' @export
 extract_key_from_url <- function(url) {
   url_start_list <-
@@ -220,12 +219,12 @@ extract_key_from_url <- function(url) {
 }
 
 #' Construct a worksheets feed from a key
-#' 
+#'
 #' @param key character, unique key for a spreadsheet
 #' @param visibility character, either "private" (default) or "public",
 #'   indicating whether further requests will be made with or without
 #'   authentication, respectively
-#'   
+#'
 #' @keywords internal
 construct_ws_feed_from_key <- function(key, visibility = "private") {
   tmp <-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,6 +6,6 @@
   )
   toset <- !(names(op.gspreadr) %in% names(op))
   if(any(toset)) options(op.gspreadr[toset])
-  
+
   invisible()
 }


### PR DESCRIPTION
Cosmetic changes. The main changes were:

1) When there was a line with two or more %>% operators, I indented all commands after the first.
2) I removed some blank lines that I felt were unnecessary, but I was not completely consistent with my choices.
3) Removed trailing spaces
4) Wrapped lines with longer than 80 characters, where convenient, using paste.