### PR TITLE
more pkgs via r_binary_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ before_install:
 install:
 - ./travis-tool.sh r_binary_install dplyr
 - ./travis-tool.sh r_binary_install XML
+- ./travis-tool.sh r_binary_install reshape2
+- ./travis-tool.sh r_binary_install stringi
+- ./travis-tool.sh r_binary_install tidyr
 - ./travis-tool.sh install_deps
 - ./travis-tool.sh github_package jimhester/covr
 script: ./travis-tool.sh run_tests


### PR DESCRIPTION
these were still being compiled in the install_deps stage

but the versions being installed match the version of the binaries available at https://launchpad.net/%7Emarutter/+archive/ubuntu/c2d4u/

so I'm going to see if I can whittle build time even more w/ explicit instructions to use r_binary_install

formatr: currently getting v1.1 but c2d4u is 1.0-1, so leaving alone

reshape2: currently getting v1.4.1 and c2d4u offers v1.4.1-1, so giving this a whirl

stringi: currently getting v0.4-1 and c2d4u offers v0.4-1-1, so giving this a whirl

tidyr: currently getting v0.2.0 and c2d4u offers v0.2.0-1, so giving this a whirl