### PR TITLE
Identify new ss via new sheet key instead of title

### DIFF
--- a/R/edit-spreadsheets.R
+++ b/R/edit-spreadsheets.R
@@ -21,12 +21,14 @@ new_ss <- function(title = "my_sheet", verbose = TRUE) {
                    mimeType = "application/vnd.google-apps.spreadsheet")
   
   req <-
-    gdrive_POST(url = "https://www.googleapis.com/drive/v2/files", the_body)
-  
+    gdrive_POST(url = "https://www.googleapis.com/drive/v2/files", 
+                body = the_body)
+
+  new_sheet_key <- httr::content(req)$id
   ## I set verbose = FALSE here because it seems weird to message "Spreadsheet
   ## identified!" in this context, esp. to do so *before* message confirming
   ## creation
-  ss <- identify_ss(title, verbose = FALSE)
+  ss <- identify_ss(new_sheet_key, verbose = FALSE)
   
   if(verbose) {
     message(sprintf("Sheet \"%s\" created in Google Drive.", ss$sheet_title))
@@ -119,7 +121,7 @@ delete_ss <- function(x = NULL, regex = NULL, verbose = TRUE, ...) {
   the_url <- paste("https://www.googleapis.com/drive/v2/files",
                    keys_to_delete, "trash", sep = "/")
   
-  post <- lapply(the_url, gdrive_POST, the_body = NULL)
+  post <- lapply(the_url, gdrive_POST, body = NULL)
   statii <- post %>% lapluck("status_code")
   sitrep <-
     dplyr::data_frame_(list(ss_title = ~ titles_to_delete,
@@ -187,7 +189,7 @@ copy_ss <- function(from, key = NULL, to = NULL, verbose = TRUE) {
   the_url <-
     paste("https://www.googleapis.com/drive/v2/files", key, "copy", sep = "/")
   
-  req <- gdrive_POST(the_url, the_body)
+  req <- gdrive_POST(the_url, body = the_body)
   
   new_title <- httr::content(req)$title
   
@@ -569,7 +571,7 @@ upload_ss <- function(file, sheet_title = NULL, verbose = TRUE) {
   }
   
   req <- gdrive_POST(url = "https://www.googleapis.com/drive/v2/files", 
-                     the_body = list(title = sheet_title, 
+                     body = list(title = sheet_title, 
                                      mimeType = "application/vnd.google-apps.spreadsheet"))
   
   new_sheet_key <- httr::content(req)$id

--- a/R/http-requests.R
+++ b/R/http-requests.R
@@ -151,10 +151,12 @@ gsheets_PUT <- function(url, the_body) {
 #' Used in new_ss(), delete_ss(), copy_ss()
 #' 
 #' @param url URL for POST request
-#' @param the_body body of POST request
+#' @param ... optional; further named parameters, such as \code{query}, 
+#'   \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed 
+#'   parameters will be combined with \code{\link[httr]{config}}.
 #' 
 #' @keywords internal
-gdrive_POST <- function(url, the_body) {
+gdrive_POST <- function(url, ...) {
   
   token <- get_google_token()
   
@@ -162,16 +164,9 @@ gdrive_POST <- function(url, the_body) {
     stop("Must be authorized user in order to perform request")
   } else {
     
-    req <- httr::POST(url, config = token, body = the_body, encode = "json")
+    req <- httr::POST(url, config = token, encode = "json", ...)
     httr::stop_for_status(req)
     req
-    
-    ## TO DO: inform users of why client error (404) Not Found may arise when
-    ## copying a spreadsheet
-    #     message(paste("The spreadsheet can not be found.",
-    #                   "Please make sure that the spreadsheet exists and that you have permission to access it.",
-    #                   'A "published to the web" spreadsheet does not necessarily mean you have permission for access.',
-    #                   "Permission for access is set in the sharing dialog of a sheets file."))
   }
 }
 

--- a/man/gdrive_POST.Rd
+++ b/man/gdrive_POST.Rd
@@ -4,12 +4,14 @@
 \alias{gdrive_POST}
 \title{Make POST request to Google Drive API}
 \usage{
-gdrive_POST(url, the_body)
+gdrive_POST(url, ...)
 }
 \arguments{
 \item{url}{URL for POST request}
 
-\item{the_body}{body of POST request}
+\item{...}{optional; further named parameters, such as \code{query},
+  \code{path}, etc, passed on to \code{\link[httr]{modify_url}}. Unnamed
+  parameters will be combined with \code{\link[httr]{config}}.}
 }
 \description{
 Used in new_ss(), delete_ss(), copy_ss()


### PR DESCRIPTION
- fixes #78
- use newly generated sheet key to re-register in new_ss(), this is better than just using title