### PR TITLE
Add check for all NULL query params

### DIFF
--- a/R/consume-data.R
+++ b/R/consume-data.R
@@ -220,6 +220,12 @@ get_via_cf <-
     ## query parameter
     query <- query %>% c(list("return-empty" = "true"))
   }
+  
+  ## to prevent appending of "?=" to url when query elements are all NULL
+  if(query %>% unlist() %>% is.null()) {
+    query <- NULL
+  }
+  
   req <- gsheets_GET(this_ws$cellsfeed, query = query)
   x <- req$content %>%
     lfilt("entry") %>%


### PR DESCRIPTION
- pass query = NULL in gsheets_GET() to stop making 2 requests 
- reason: even if all query params are NULL, “?=“ gets appended to the url and causes GET to return “HTTP/1.1 302 Moved Temporarily” and then make another request to the url after removing the “?=“
