### PR TITLE
covr is ok again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - ./travis-tool.sh r_binary_install stringi
 - ./travis-tool.sh r_binary_install tidyr
 - ./travis-tool.sh install_deps
-- ./travis-tool.sh github_package jimhester/covr
+- ./travis-tool.sh github_package jimhester/covr@6c6057d8689325fb41f8e4d6a1fd023c387253c6
 script: ./travis-tool.sh run_tests
 after_script:
 - ./travis-tool.sh dump_sysinfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
 - ./travis-tool.sh r_binary_install stringi
 - ./travis-tool.sh r_binary_install tidyr
 - ./travis-tool.sh install_deps
-- ./travis-tool.sh github_package jimhester/robustr
 - ./travis-tool.sh github_package jimhester/covr
 script: ./travis-tool.sh run_tests
 after_script:


### PR DESCRIPTION
I verified that the dependency on github-only robustr has been removed (temporarily glossed over on the covr end, actually). Also pegged our use of covr to a specific commit via SHA1 so this can't unexpectedly break our builds again. Once covr is on CRAN, we should probably install from there on travis, to get this stability.

https://github.com/jimhester/covr/issues/80