### PR TITLE
Allow gs_add_row to add multiple rows if given rectangular data

### DIFF
--- a/R/gs_add_row.R
+++ b/R/gs_add_row.R
@@ -39,6 +39,15 @@
 
 gs_add_row <- function(ss, ws = 1, input = '', verbose = TRUE) {
 
+  nrows <- nrow(input)
+  if (!is.null(nrows) && nrows > 1) {
+
+    for (i in seq_len(nrows)) {
+      ss <- Recall(ss = ss, ws = ws, input = input[i, ], verbose = verbose)
+    }
+    return(invisible(ss))
+  }
+
   ## this fxn defined in gs_edit_cells.R
   input <- as_character_vector(input, col_names = FALSE)
 

--- a/tests/testthat/test-cell-edit.R
+++ b/tests/testthat/test-cell-edit.R
@@ -157,5 +157,14 @@ test_that("Row input is given the proper length", {
 
 })
 
+test_that("We can add multiple rows", {
+  ws <- "shipwrecks"
+  input <- dplyr::data_frame(id = c("Dona Paz", "USS Arizona"), wreckdate = c("1987-12-20", "1941-12-07"))
+
+  ss <- ss %>% gs_add_row(ws = ws, input = input)
+  expect_is(ss, "googlesheet")
+  expect_equal(ss %>% gs_read(ws = ws) %>% tail(2), input)
+})
+
 gs_grepdel(TEST, verbose = FALSE)
 gs_auth_suspend(verbose = FALSE)


### PR DESCRIPTION
This just modifies gs_add_row to repeatedly call itself if the input data is rectangular. I added a simple test, if you think more are appropriate let me know.

I don't know if it would be wise to add a sleep in between the calls, in my testing I have not found it necessary.