### PR TITLE
Update gs_read_csv.R

### DIFF
--- a/R/gs_read_csv.R
+++ b/R/gs_read_csv.R
@@ -72,11 +72,11 @@ gs_read_csv <- function(ss, ws = 1, ..., verbose = TRUE) {
     ## numeric columns have an NA for empty cells
     ## character columns have "" for empty cells
     ## hence the value of na.strings
-    req %>%
-      httr::content(type = "text/csv", na.strings = c("", "NA"),
-                    encoding = "UTF-8", ...) %>%
-      dplyr::as_data_frame() %>%
-      dplyr::as.tbl()
+    ## req %>%
+    ##   httr::content(type = "text/csv", na.strings = c("", "NA"),
+    ##                 encoding = "UTF-8", ...) %>%
+    ##   dplyr::as_data_frame() %>%
+    ##   dplyr::as.tbl()
     ## in future, I'm interested in using readr::read_csv(), either directly
     ## or indirectly, if httr make it the parser when MIME type is text/csv
     ## won't do it know because doesn't support vector valued na.strings,
@@ -86,9 +86,9 @@ gs_read_csv <- function(ss, ws = 1, ..., verbose = TRUE) {
     ## https://github.com/hadley/readr/issues/114
     ## https://github.com/hadley/readr/issues/125
     ## parsing content "by hand" with readr_csv() might look like so:
-    ## req %>%
-    ##   httr::content(type = "text", encoding = "UTF-8") %>%
-    ##   readr::read_csv()
+    req %>%
+      httr::content(type = "text", encoding = "UTF-8") %>%
+      readr::read_csv()
   }
 
 }


### PR DESCRIPTION
With the current version of httr, [this example](https://gist.github.com/zkamvar/64d704358644167c39a5) fails and complains about the argument `na.strings`


```r
library("googlesheets")
library("magrittr")
ex_key <- "1N58tQL5ioci4_JripPZgvpxiNQ_Ky4WWpD364oVvMCY" 
participants <- ex_key %>% 
    gs_key(lookup = FALSE) %>%      # register the sheet with R
    gs_read()
```


This is an update in response to httr version 1.1.0. I don't know exactly why this works, I just uncommented things :) I would imagine that this is one step of a larger fix.

