### PR TITLE
Use xml2::xml_find_first() instead of deprecated xml2::xml_find_one()

### DIFF
--- a/R/googlesheet.R
+++ b/R/googlesheet.R
@@ -44,9 +44,9 @@ as.googlesheet.ws_feed <- function(x, ssf = NULL,
 
   ss$sheet_key <- req$url %>% extract_key_from_url()
   ss$sheet_title <- rc %>%
-    xml2::xml_find_one("./feed:title", ns) %>% xml2::xml_text()
+    xml2::xml_find_first("./feed:title", ns) %>% xml2::xml_text()
   ss$n_ws <- rc %>%
-    xml2::xml_find_one("./openSearch:totalResults", ns) %>%
+    xml2::xml_find_first("./openSearch:totalResults", ns) %>%
     xml2::xml_text() %>%
     as.integer()
 
@@ -61,9 +61,9 @@ as.googlesheet.ws_feed <- function(x, ssf = NULL,
   ss$is_public <- ss$visibility == "public"
 
   ss$author <- rc %>%
-    xml2::xml_find_one("./feed:author/feed:name", ns) %>% xml2::xml_text()
+    xml2::xml_find_first("./feed:author/feed:name", ns) %>% xml2::xml_text()
   ss$email <- rc %>%
-    xml2::xml_find_one("./feed:author/feed:email", ns) %>% xml2::xml_text()
+    xml2::xml_find_first("./feed:author/feed:email", ns) %>% xml2::xml_text()
 
   ## FIXME: this is way of setting perm is clearly incorrect; redo this based on
   ## permissions or capabilities

--- a/R/gs_add_row.R
+++ b/R/gs_add_row.R
@@ -67,7 +67,7 @@ gs_add_row <- function(ss, ws = 1, input = '', verbose = TRUE) {
   ns <- xml2::xml_ns_rename(xml2::xml_ns(rc), d1 = "feed")
 
   var_names <- rc %>%
-    xml2::xml_find_one("(//feed:entry)[1]", ns) %>%
+    xml2::xml_find_first("(//feed:entry)[1]", ns) %>%
     xml2::xml_find_all(".//gsx:*", ns) %>%
     xml2::xml_name()
   nc <- length(var_names)
@@ -86,7 +86,7 @@ gs_add_row <- function(ss, ws = 1, input = '', verbose = TRUE) {
   stopifnot(length(input) == nc)
 
   lf_post_link <- rc %>%
-    xml2::xml_find_one("//feed:link[contains(@rel,'2005#post')]", ns) %>%
+    xml2::xml_find_first("//feed:link[contains(@rel,'2005#post')]", ns) %>%
     xml2::xml_attr("href")
 
   child_node_names <- paste("gsx", var_names, sep = ":")

--- a/R/gs_ws.R
+++ b/R/gs_ws.R
@@ -324,16 +324,16 @@ gs_ws_modify <- function(ss, from = NULL, to = NULL,
                 "\"%s\".\nPlease choose another worksheet title."),
           to, ss$sheet_title)
     }
-    title_node <- xml2::xml_find_one(rc, "//d1:title", xml2::xml_ns(rc))
+    title_node <- xml2::xml_find_first(rc, "//d1:title", xml2::xml_ns(rc))
     xml2::xml_text(title_node) <- to
   }
 
   if (!is.null(new_dim)) { # resize a worksheet
     stopifnot(is.numeric(new_dim),
               identical(names(new_dim), c("row_extent", "col_extent")))
-    rowCount_node <- xml2::xml_find_one(rc, "//gs:rowCount", xml2::xml_ns(rc))
+    rowCount_node <- xml2::xml_find_first(rc, "//gs:rowCount", xml2::xml_ns(rc))
     xml2::xml_text(rowCount_node) <- as.character(new_dim["row_extent"])
-    colCount_node <- xml2::xml_find_one(rc, "//gs:colCount", xml2::xml_ns(rc))
+    colCount_node <- xml2::xml_find_first(rc, "//gs:colCount", xml2::xml_ns(rc))
     xml2::xml_text(colCount_node) <- as.character(new_dim["col_extent"])
   }
 

--- a/internal-projects/09_understanding-the-feeds.Rmd
+++ b/internal-projects/09_understanding-the-feeds.Rmd
@@ -51,7 +51,7 @@ entries <- req$content %>%
   xml_path()
 length(entries)
 req$content %>%
-  xml_find_one(entries[1])
+  xml_find_first(entries[1])
 ```
 
 The `entry` nodes have same structure for each sheet, which we explore via the first entry = sheet. What is all this stuff?
@@ -93,7 +93,7 @@ Each `entry` node has an `id` element containing a URL plus 3 additional nodes n
 
 ```{r}
 jfun <- function(x) { # gymnastics required for one sheet's worth of links
-  x <- req$content %>% xml_find_one(x)
+  x <- req$content %>% xml_find_first(x)
   links <- x %>% 
     xml_find_all("feed:link", ns) %>% 
     lapply(xml_attrs) %>% 
@@ -103,10 +103,10 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     mutate(source = "content/entry/link")
   links %>%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %>% xml_find_one("feed:id", ns) %>% xml_text(),
+                     href = x %>% xml_find_first("feed:id", ns) %>% xml_text(),
                      source = "content/entry/id")) %>% 
     mutate(feed = "ss",
-           sheet_title = x %>% xml_find_one("feed:title", ns) %>% xml_text()) %>% 
+           sheet_title = x %>% xml_find_first("feed:title", ns) %>% xml_text()) %>% 
     select(sheet_title, feed, source, href, rel, type)
 }
 links <- entries %>% lapply(jfun) %>% 
@@ -365,7 +365,7 @@ knitr::kable(sapply(content, g), format = "html",
 The variation is in the multiplicity of `link` and `entry` elements.  We pursue that below, but let's inspect the more boring components before we move on. We can predict what some of this stuff is based on what we saw in the spreadsheets feed. I'm also going to check if the info here agrees with the spreadsheets feed.
 
 ```{r}
-f <- function(x, xpath) xml_find_one(x, xpath, ns_ws) %>% xml_text()
+f <- function(x, xpath) xml_find_first(x, xpath, ns_ws) %>% xml_text()
 wsf_stuff <-
   data_frame(title = sapply(content, f, "feed:title"),
              updated = sapply(content, f, "feed:updated"),
@@ -454,10 +454,10 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     mutate(source = "content/entry/link")
   links %>%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %>% xml_find_one("feed:id", ns_ws) %>% xml_text(),
+                     href = x %>% xml_find_first("feed:id", ns_ws) %>% xml_text(),
                      source = "content/entry/id")) %>% 
     mutate(feed = "ws",
-           sheet_title = x %>% xml_find_one("feed:title", ns_ws)
+           sheet_title = x %>% xml_find_first("feed:title", ns_ws)
            %>% xml_text()) %>% 
     select(sheet_title, feed, source, href, rel, type)
 }
@@ -650,7 +650,7 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     bind_rows()
   links %>%
     mutate(sheet_title = x %>%
-             xml_find_one("feed:title", ns_ws) %>% xml_text()) %>% 
+             xml_find_first("feed:title", ns_ws) %>% xml_text()) %>% 
     select(sheet_title, href, rel, type)
 }
 one_ws_links <-

--- a/internal-projects/09_understanding-the-feeds.html
+++ b/internal-projects/09_understanding-the-feeds.html
@@ -117,7 +117,7 @@ entries &lt;- req$content %&gt;%
 length(entries)</code></pre>
 <pre><code>## [1] 36</code></pre>
 <pre class="r"><code>req$content %&gt;%
-  xml_find_one(entries[1])</code></pre>
+  xml_find_first(entries[1])</code></pre>
 <pre><code>## {xml_node}
 ## &lt;entry&gt;
 ## [1] &lt;id&gt;https://spreadsheets.google.com/feeds/spreadsheets/private/full/ ...
@@ -174,7 +174,7 @@ title_stuff</code></pre>
 <h3>Marshall all links returned by the spreadsheets feed</h3>
 <p>Each <code>entry</code> node has an <code>id</code> element containing a URL plus 3 additional nodes named <code>link</code>. I gather all 4 into a <code>tbl_df</code> for systematic exploration</p>
 <pre class="r"><code>jfun &lt;- function(x) { # gymnastics required for one sheet's worth of links
-  x &lt;- req$content %&gt;% xml_find_one(x)
+  x &lt;- req$content %&gt;% xml_find_first(x)
   links &lt;- x %&gt;% 
     xml_find_all(&quot;feed:link&quot;, ns) %&gt;% 
     lapply(xml_attrs) %&gt;% 
@@ -184,10 +184,10 @@ title_stuff</code></pre>
     mutate(source = &quot;content/entry/link&quot;)
   links %&gt;%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %&gt;% xml_find_one(&quot;feed:id&quot;, ns) %&gt;% xml_text(),
+                     href = x %&gt;% xml_find_first(&quot;feed:id&quot;, ns) %&gt;% xml_text(),
                      source = &quot;content/entry/id&quot;)) %&gt;% 
     mutate(feed = &quot;ss&quot;,
-           sheet_title = x %&gt;% xml_find_one(&quot;feed:title&quot;, ns) %&gt;% xml_text()) %&gt;% 
+           sheet_title = x %&gt;% xml_find_first(&quot;feed:title&quot;, ns) %&gt;% xml_text()) %&gt;% 
     select(sheet_title, feed, source, href, rel, type)
 }
 links &lt;- entries %&gt;% lapply(jfun) %&gt;% 
@@ -914,7 +914,7 @@ entry
 </tbody>
 </table>
 <p>The variation is in the multiplicity of <code>link</code> and <code>entry</code> elements. We pursue that below, but let’s inspect the more boring components before we move on. We can predict what some of this stuff is based on what we saw in the spreadsheets feed. I’m also going to check if the info here agrees with the spreadsheets feed.</p>
-<pre class="r"><code>f &lt;- function(x, xpath) xml_find_one(x, xpath, ns_ws) %&gt;% xml_text()
+<pre class="r"><code>f &lt;- function(x, xpath) xml_find_first(x, xpath, ns_ws) %&gt;% xml_text()
 wsf_stuff &lt;-
   data_frame(title = sapply(content, f, &quot;feed:title&quot;),
              updated = sapply(content, f, &quot;feed:updated&quot;),
@@ -1278,10 +1278,10 @@ ari copy
     mutate(source = &quot;content/entry/link&quot;)
   links %&gt;%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %&gt;% xml_find_one(&quot;feed:id&quot;, ns_ws) %&gt;% xml_text(),
+                     href = x %&gt;% xml_find_first(&quot;feed:id&quot;, ns_ws) %&gt;% xml_text(),
                      source = &quot;content/entry/id&quot;)) %&gt;% 
     mutate(feed = &quot;ws&quot;,
-           sheet_title = x %&gt;% xml_find_one(&quot;feed:title&quot;, ns_ws)
+           sheet_title = x %&gt;% xml_find_first(&quot;feed:title&quot;, ns_ws)
            %&gt;% xml_text()) %&gt;% 
     select(sheet_title, feed, source, href, rel, type)
 }
@@ -1716,7 +1716,7 @@ ws_links %&gt;% sapply(length)</code></pre>
     bind_rows()
   links %&gt;%
     mutate(sheet_title = x %&gt;%
-             xml_find_one(&quot;feed:title&quot;, ns_ws) %&gt;% xml_text()) %&gt;% 
+             xml_find_first(&quot;feed:title&quot;, ns_ws) %&gt;% xml_text()) %&gt;% 
     select(sheet_title, href, rel, type)
 }
 one_ws_links &lt;-

--- a/internal-projects/09_understanding-the-feeds.md
+++ b/internal-projects/09_understanding-the-feeds.md
@@ -52,7 +52,7 @@ length(entries)
 
 ```r
 req$content %>%
-  xml_find_one(entries[1])
+  xml_find_first(entries[1])
 ```
 
 ```
@@ -135,7 +135,7 @@ Each `entry` node has an `id` element containing a URL plus 3 additional nodes n
 
 ```r
 jfun <- function(x) { # gymnastics required for one sheet's worth of links
-  x <- req$content %>% xml_find_one(x)
+  x <- req$content %>% xml_find_first(x)
   links <- x %>% 
     xml_find_all("feed:link", ns) %>% 
     lapply(xml_attrs) %>% 
@@ -145,10 +145,10 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     mutate(source = "content/entry/link")
   links %>%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %>% xml_find_one("feed:id", ns) %>% xml_text(),
+                     href = x %>% xml_find_first("feed:id", ns) %>% xml_text(),
                      source = "content/entry/id")) %>% 
     mutate(feed = "ss",
-           sheet_title = x %>% xml_find_one("feed:title", ns) %>% xml_text()) %>% 
+           sheet_title = x %>% xml_find_first("feed:title", ns) %>% xml_text()) %>% 
     select(sheet_title, feed, source, href, rel, type)
 }
 links <- entries %>% lapply(jfun) %>% 
@@ -931,7 +931,7 @@ The variation is in the multiplicity of `link` and `entry` elements.  We pursue 
 
 
 ```r
-f <- function(x, xpath) xml_find_one(x, xpath, ns_ws) %>% xml_text()
+f <- function(x, xpath) xml_find_first(x, xpath, ns_ws) %>% xml_text()
 wsf_stuff <-
   data_frame(title = sapply(content, f, "feed:title"),
              updated = sapply(content, f, "feed:updated"),
@@ -1179,10 +1179,10 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     mutate(source = "content/entry/link")
   links %>%
     rbind(data.frame(rel = NA, type = NA,
-                     href = x %>% xml_find_one("feed:id", ns_ws) %>% xml_text(),
+                     href = x %>% xml_find_first("feed:id", ns_ws) %>% xml_text(),
                      source = "content/entry/id")) %>% 
     mutate(feed = "ws",
-           sheet_title = x %>% xml_find_one("feed:title", ns_ws)
+           sheet_title = x %>% xml_find_first("feed:title", ns_ws)
            %>% xml_text()) %>% 
     select(sheet_title, feed, source, href, rel, type)
 }
@@ -1566,7 +1566,7 @@ jfun <- function(x) { # gymnastics required for one sheet's worth of links
     bind_rows()
   links %>%
     mutate(sheet_title = x %>%
-             xml_find_one("feed:title", ns_ws) %>% xml_text()) %>% 
+             xml_find_first("feed:title", ns_ws) %>% xml_text()) %>% 
     select(sheet_title, href, rel, type)
 }
 one_ws_links <-


### PR DESCRIPTION
The next version of xml2 will be deprecating xml_find_one() in favor of
xml_find_first(). The new function is a drop in replacement for the old, and no
longer issues a warning when more than one result would be returned.