### PR TITLE
Add overwrite argument to gs_upload()

### DIFF
--- a/man/gs_upload.Rd
+++ b/man/gs_upload.Rd
@@ -4,13 +4,15 @@
 \alias{gs_upload}
 \title{Upload a file and convert it to a Google Sheet}
 \usage{
-gs_upload(file, sheet_title = NULL, verbose = TRUE)
+gs_upload(file, sheet_title = NULL, verbose = TRUE, overwrite = FALSE)
 }
 \arguments{
 \item{file}{path to the file to upload}
 
 \item{sheet_title}{the title of the spreadsheet; optional, if not specified
 then the name of the file will be used}
+
+\item{overwrite}{whether to overwrite an existing file with the same name}
 
 \item{verbose}{logical; do you want informative messages?}
 }
@@ -32,4 +34,3 @@ gs_delete(iris_ss)
 }
 
 }
-

--- a/tests/testthat/test-gs-upload.R
+++ b/tests/testthat/test-gs-upload.R
@@ -33,5 +33,36 @@ test_that("Different file formats can be uploaded", {
 
 })
 
+test_that("Overwrite actually overwrites an existing file", {
+  
+  # Reference data
+  df1 <- data.frame(x=1)
+  df2 <- data.frame(x=2)
+  write.csv(df1, "df1.csv", row.names = F)
+  write.csv(df2, "df2.csv", row.names = F)
+  orig_file <- gs_upoad("df1.csv")
+  Sys.sleep(1)
+  # Generate 2 files: 1 using gs_edit, 1 using gs_upload(overwrite = T), which should be identical at the end
+  # First using editing
+  edited_file <- gs_copy(orig_file, to = "edited_file")
+  Sys.sleep(1)
+  gs_edit_cells(edited_file, input = df2)
+  Sys.sleep(1)
+  edited_file_content <- gs_read(edited_file)
+  Sys.sleep(1)
+  # Second using overwrite
+  overwritten_file <- gs_copy(orig_file, to = "overwritten_file")
+  Sys.sleep(1)
+  gs_upload("df2.csv", sheet_title = "df1", overwrite = T)
+  Sys.sleep(1)
+  overwritten_file_content <- gs_read(overwritten_file)
+  # Perform the test
+  expect_that(edited_file_content, equals(overwritten_file_content))
+
+  # Todo: test overwrite for identical name
+  
+})
+
+
 gs_grepdel(TEST, verbose = FALSE)
 gs_deauth(verbose = FALSE)


### PR DESCRIPTION
overwrite specifies whether a user wants to overwrite an existing sheet with an identical name when uploading a file