### PR TITLE
Quieter readr calls

### DIFF
--- a/R/gs_reshape_cellfeed.R
+++ b/R/gs_reshape_cellfeed.R
@@ -119,10 +119,11 @@ gs_reshape_feed <- function(x, ddd, verbose = TRUE) {
 
   allowed_args <- c("col_types", "locale", "trim_ws", "na")
   type_convert_args <- c(list(df = dat), dropnulls(ddd[allowed_args]))
-  if (verbose)
+  if (verbose) {
     df <- do.call(readr::type_convert, type_convert_args)
-  else
+  } else {
     suppressMessages({df <- do.call(readr::type_convert, type_convert_args)})
+  }
 
   ## our departures from readr data ingest:
   ## ~~no NA variable names~~ handled elsewhere (above) in this function

--- a/R/gs_reshape_cellfeed.R
+++ b/R/gs_reshape_cellfeed.R
@@ -119,7 +119,10 @@ gs_reshape_feed <- function(x, ddd, verbose = TRUE) {
 
   allowed_args <- c("col_types", "locale", "trim_ws", "na")
   type_convert_args <- c(list(df = dat), dropnulls(ddd[allowed_args]))
-  df <- do.call(readr::type_convert, type_convert_args)
+  if (verbose)
+    df <- do.call(readr::type_convert, type_convert_args)
+  else
+    suppressMessages({df <- do.call(readr::type_convert, type_convert_args)})
 
   ## our departures from readr data ingest:
   ## ~~no NA variable names~~ handled elsewhere (above) in this function

--- a/R/gs_simplify_cellfeed.R
+++ b/R/gs_simplify_cellfeed.R
@@ -84,7 +84,7 @@ gs_simplify_cellfeed <- function(
     }
 
     type_convert_args <- c(list(df = x["value"]), dropnulls(ddd))
-    df <- do.call(readr::type_convert, type_convert_args)
+    suppressMessages({df <- do.call(readr::type_convert, type_convert_args)})
     x$value <- df$value
   }
 


### PR DESCRIPTION
gs_read_listfeed() would still output a message ("Parsed with column specification..."), regardless of the `verbose` argument. I wrapped the `readr` calls in `suppressMessages()`, conditionals where appropriate
