### PR TITLE
Change regexp to detect Google Docs URL

### DIFF
--- a/R/gd_metadata.R
+++ b/R/gd_metadata.R
@@ -25,9 +25,13 @@ gd_metadata <- function(id, auth = TRUE) {
   httr::content(req)
 }
 
-gd_rename <- function(id, to) {
+gd_rename <- function(id, to, teamDrive = FALSE) {
   stopifnot(is.character(to), length(to) == 1L)
-  req <- httr::PATCH(file.path(.state$gd_base_url_files_v3, id),
+  the_url <- file.path(.state$gd_base_url_files_v3, id)
+  if (teamDrive) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
+  req <- httr::PATCH(the_url,
                      google_token(), encode = "json",
                      body = list(name = to)) %>%
     httr::stop_for_status()

--- a/R/googlesheet.R
+++ b/R/googlesheet.R
@@ -79,7 +79,7 @@ as.googlesheet.ws_feed <- function(x, ssf = NULL,
     href = ~ links %>% xml2::xml_attr("href")
   ))
 
-  if(grepl("^https://docs.google.com/spreadsheets/d",
+  if(grepl("^https://docs.google.com/(.+/)?spreadsheets/d/",
            ss$links$href[ss$links$rel == "alternate"])) {
     ss$version <- "new"
   }

--- a/R/gs_copy.R
+++ b/R/gs_copy.R
@@ -36,6 +36,9 @@ gs_copy <- function(from, to = NULL, verbose = TRUE) {
   }
 
   the_url <- file.path(.state$gd_base_url_files_v2, key, "copy")
+  if (check_sheet_on_team_drive(from)) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
   the_body <- list("title" = to)
   req <-
     httr::POST(the_url, google_token(), encode = "json", body = the_body) %>%

--- a/R/gs_copy.R
+++ b/R/gs_copy.R
@@ -45,7 +45,7 @@ gs_copy <- function(from, to = NULL, verbose = TRUE) {
     httr::stop_for_status()
   rc <- content_as_json_UTF8(req)
 
-  new_ss <- try(gs_key(rc$id, verbose = FALSE), silent = TRUE)
+  new_ss <- try(gs_key(rc$id, verbose = FALSE, lookup=from$lookup, visibility=from$visibility), silent = TRUE)
 
   cannot_find_sheet <- inherits(new_ss, "try-error")
 

--- a/R/gs_delete.R
+++ b/R/gs_delete.R
@@ -37,6 +37,9 @@ gs_delete <- function(ss, verbose = TRUE) {
 
   key <- gs_get_alt_key(ss)
   the_url <- file.path(.state$gd_base_url_files_v2, key)
+  if (check_sheet_on_team_drive(ss)) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
 
   req <- httr::DELETE(the_url, google_token()) %>%
     httr::stop_for_status()

--- a/R/gs_edit_cells.R
+++ b/R/gs_edit_cells.R
@@ -163,7 +163,7 @@ gs_edit_cells <- function(ss, ws = 1, input = '', anchor = 'A1',
   }
 
   Sys.sleep(sleep)
-  ss <- ss$sheet_key %>% gs_key(verbose = FALSE)
+  ss <- ss$sheet_key %>% gs_key(verbose = FALSE, lookup=ss$lookup, visibility=ss$visibility)
   invisible(ss)
 }
 

--- a/R/gs_ls.R
+++ b/R/gs_ls.R
@@ -98,7 +98,7 @@ gs_ls <- function(regex = NULL, ..., verbose = TRUE) {
     perm = ~ link_dat$ws_feed %>%
       stringr::str_detect("values") %>%
       ifelse("r", "rw"),
-    version = ~ ifelse(grepl("^https://docs.google.com/spreadsheets/d",
+    version = ~ ifelse(grepl("^https://docs.google.com/(.+/)?spreadsheets/d/",
                              link_dat$alternate), "new", "old"),
     updated =
       ~ entries %>% xml2::xml_find_all(".//feed:updated", ns) %>%

--- a/R/gs_rename.R
+++ b/R/gs_rename.R
@@ -44,6 +44,6 @@ gs_rename <- function(ss, to, verbose = TRUE) {
     }
   }
   fr$id %>%
-    gs_key(verbose = FALSE) %>%
+    gs_key(verbose = FALSE, lookup=ss$lookup, visibility=ss$visibility) %>%
     invisible()
 }

--- a/R/gs_rename.R
+++ b/R/gs_rename.R
@@ -34,7 +34,7 @@ gs_rename <- function(ss, to, verbose = TRUE) {
         ss$sheet_title)
   }
 
-  fr <- gd_rename(ss$sheet_key, to)
+  fr <- gd_rename(ss$sheet_key, to, teamDrive=check_sheet_on_team_drive(ss))
   if (verbose) {
     if (!identical(fr$name, to)) {
       mpf("Cannot confirm that target Sheet \"%s\" was renamed to \"%s\"",

--- a/R/gs_ws.R
+++ b/R/gs_ws.R
@@ -72,7 +72,7 @@ gs_ws_new <- function(ss, ws_title = "Sheet1",
 
   ss <- req$url %>%
     extract_key_from_url() %>%
-    gs_key(verbose = FALSE)
+    gs_key(verbose = FALSE, lookup=ss$lookup, visibility=ss$visibility)
 
   ws_title_exist <- ws_title %in% gs_ws_ls(ss)
 
@@ -140,7 +140,8 @@ gs_ws_delete <- function(ss, ws = 1, verbose = TRUE) {
   req <- httr::DELETE(this_ws$ws_id, google_token()) %>%
     httr::stop_for_status()
 
-  ss_refresh <- ss$sheet_key %>% gs_key(verbose = FALSE)
+  ss_refresh <- ss$sheet_key %>% gs_key(verbose = FALSE,
+                                        lookup=ss$lookup, visibility=ss$visibility)
 
   ws_title_exist <- this_ws$ws_title %in% gs_ws_ls(ss_refresh)
 
@@ -346,7 +347,7 @@ gs_ws_modify <- function(ss, from = NULL, to = NULL,
 
   req$url %>%
     extract_key_from_url() %>%
-    gs_key(verbose = verbose)
+    gs_key(verbose = verbose, lookup=ss$lookup, visibility=ss$visibility)
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,7 @@ extract_key_from_url <- function(url) {
   url_start_list <-
     c(ws_feed_start = "https://spreadsheets.google.com/feeds/worksheets/",
       self_link_start = "https://spreadsheets.google.com/feeds/spreadsheets/private/full/",
-      url_start_new = "https://docs.google.com/spreadsheets/d/",
+      url_start_new = "https://docs.google.com/(.+/)?spreadsheets/d/",
       url_start_google_apps_for_work = "https://docs.google.com/a/[[:print:]]+/spreadsheets/d/",
       url_start_old = "https://docs.google.com/spreadsheet/ccc\\?key=",
       url_start_old2 = "https://docs.google.com/spreadsheet/pub\\?key=",

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,6 +44,19 @@ construct_ws_feed_from_key <- function(key, visibility = "private") {
   sprintf(tmp, key, visibility)
 }
 
+#' Heuristic check whether spreadsheet resides on a team drive
+#'
+#' sort of hackish workaround. Check if alternate URL includes a domain name
+#'
+#' @template ss
+#'
+#' @keywords internal
+check_sheet_on_team_drive <- function(ss) {
+  alt_link <- ss$links$href[ss$links$rel=="alternate"]
+  !is.null(alt_link) && length(alt_link) > 0 &&
+    stringr::str_detect(alt_link, "https://docs.google.com/.+/spreadsheets/d/")
+}
+
 #' Construct a browser URL from a key
 #'
 #' @param key character, unique key for a spreadsheet


### PR DESCRIPTION
change regexp to detect Google Docs URL to allow also
for links to Team drives, e.g. on corporate accounts.
Allow links like: https://docs.google.com/a/example.com/spreadsheets/d/...

By allowing also those corporate URL's, `gs_ls()` and `as.googlesheet` will assign `version="new"`

Also `extract_key_from_url` will be fixed such that key-extraction works in below example
```R
extract_key_from_url("https://docs.google.com/a/example.com/spreadsheets/d/XXXXnoTL0ngKEYXXXX/edit#gid=0")
```

This PR is a prerequisite to fix #315.

