### PR TITLE
Enabling "supportTeamDrives" Flag for GD API

### DIFF
--- a/R/gd_metadata.R
+++ b/R/gd_metadata.R
@@ -25,9 +25,13 @@ gd_metadata <- function(id, auth = TRUE) {
   httr::content(req)
 }
 
-gd_rename <- function(id, to) {
+gd_rename <- function(id, to, teamDrive = FALSE) {
   stopifnot(is.character(to), length(to) == 1L)
-  req <- httr::PATCH(file.path(.state$gd_base_url_files_v3, id),
+  the_url <- file.path(.state$gd_base_url_files_v3, id)
+  if (teamDrive) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
+  req <- httr::PATCH(the_url,
                      google_token(), encode = "json",
                      body = list(name = to)) %>%
     httr::stop_for_status()

--- a/R/gs_copy.R
+++ b/R/gs_copy.R
@@ -36,6 +36,9 @@ gs_copy <- function(from, to = NULL, verbose = TRUE) {
   }
 
   the_url <- file.path(.state$gd_base_url_files_v2, key, "copy")
+  if (check_sheet_on_team_drive(from)) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
   the_body <- list("title" = to)
   req <-
     httr::POST(the_url, google_token(), encode = "json", body = the_body) %>%

--- a/R/gs_delete.R
+++ b/R/gs_delete.R
@@ -37,6 +37,9 @@ gs_delete <- function(ss, verbose = TRUE) {
 
   key <- gs_get_alt_key(ss)
   the_url <- file.path(.state$gd_base_url_files_v2, key)
+  if (check_sheet_on_team_drive(ss)) {
+    the_url <- paste0(the_url, "?supportsTeamDrives=true")
+  }
 
   req <- httr::DELETE(the_url, google_token()) %>%
     httr::stop_for_status()

--- a/R/gs_rename.R
+++ b/R/gs_rename.R
@@ -34,7 +34,7 @@ gs_rename <- function(ss, to, verbose = TRUE) {
         ss$sheet_title)
   }
 
-  fr <- gd_rename(ss$sheet_key, to)
+  fr <- gd_rename(ss$sheet_key, to, teamDrive=check_sheet_on_team_drive(ss))
   if (verbose) {
     if (!identical(fr$name, to)) {
       mpf("Cannot confirm that target Sheet \"%s\" was renamed to \"%s\"",

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,6 +44,19 @@ construct_ws_feed_from_key <- function(key, visibility = "private") {
   sprintf(tmp, key, visibility)
 }
 
+#' Heuristic check whether spreadsheet resides on a team drive
+#'
+#' sort of hackish workaround. Check if alternate URL includes a domain name
+#'
+#' @template ss
+#'
+#' @keywords internal
+check_sheet_on_team_drive <- function(ss) {
+  alt_link <- ss$links$href[ss$links$rel=="alternate"]
+  !is.null(alt_link) && length(alt_link) > 0 &&
+    stringr::str_detect(alt_link, "https://docs.google.com/.+/spreadsheets/d/")
+}
+
 #' Construct a browser URL from a key
 #'
 #' @param key character, unique key for a spreadsheet


### PR DESCRIPTION
Enabling "supportTeamDrives" Flag for the Goggle Drive API in case Team Drive URL is detected.

Detection of Team drive heuristically through the alternate URL.
No side effect on files not sitting on TeamDrives.

Prerequisite for solving #315 