### PR TITLE
change regexp to detect Google Docs URL

### DIFF
--- a/R/googlesheet.R
+++ b/R/googlesheet.R
@@ -79,7 +79,7 @@ as.googlesheet.ws_feed <- function(x, ssf = NULL,
     href = ~ links %>% xml2::xml_attr("href")
   ))
 
-  if(grepl("^https://docs.google.com/spreadsheets/d",
+  if(grepl("^https://docs.google.com/(.+/)?spreadsheets/d/",
            ss$links$href[ss$links$rel == "alternate"])) {
     ss$version <- "new"
   }

--- a/R/gs_ls.R
+++ b/R/gs_ls.R
@@ -98,7 +98,7 @@ gs_ls <- function(regex = NULL, ..., verbose = TRUE) {
     perm = ~ link_dat$ws_feed %>%
       stringr::str_detect("values") %>%
       ifelse("r", "rw"),
-    version = ~ ifelse(grepl("^https://docs.google.com/spreadsheets/d",
+    version = ~ ifelse(grepl("^https://docs.google.com/(.+/)?spreadsheets/d/",
                              link_dat$alternate), "new", "old"),
     updated =
       ~ entries %>% xml2::xml_find_all(".//feed:updated", ns) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,7 @@ extract_key_from_url <- function(url) {
   url_start_list <-
     c(ws_feed_start = "https://spreadsheets.google.com/feeds/worksheets/",
       self_link_start = "https://spreadsheets.google.com/feeds/spreadsheets/private/full/",
-      url_start_new = "https://docs.google.com/spreadsheets/d/",
+      url_start_new = "https://docs.google.com/(.+/)?spreadsheets/d/",
       url_start_google_apps_for_work = "https://docs.google.com/a/[[:print:]]+/spreadsheets/d/",
       url_start_old = "https://docs.google.com/spreadsheet/ccc\\?key=",
       url_start_old2 = "https://docs.google.com/spreadsheet/pub\\?key=",


### PR DESCRIPTION
change regexp to detect Google Docs URL to allow also
for links to Team drives, e.g. on corporate accounts.
Allow links like: https://docs.google.com/a/example.com/spreadsheets/d/...

Needed to solve #315 

this will set 'version="new"' for files sitting on Team Drives in `as.googlesheet` and `gs_ls`.
Plus it allows `extract_key_from_url` to work on such URLS:

```r
extract_key_from_url("https://docs.google.com/a/example.com/spreadsheets/d/XXXXnoTL0ngKEYXXXX/edit#gid=0"
```